### PR TITLE
Fix .env.example inline comments breaking Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,25 +3,41 @@
 # ============================================
 # Copy this file to .env and fill in your keys.
 # Keys are optional — sources without keys degrade gracefully.
+#
+# IMPORTANT: Do NOT put comments on the same line as values.
+# Docker env_file treats inline comments as part of the value.
 
 # === OSINT Source API Keys ===
-FRED_API_KEY=              # Federal Reserve Economic Data (free: fred.stlouisfed.org/docs/api)
-FIRMS_MAP_KEY=             # NASA FIRMS fire data (free: firms.modaps.eosdis.nasa.gov/api)
-EIA_API_KEY=               # Energy Information Administration (free: api.eia.gov/register)
-AISSTREAM_API_KEY=         # Maritime AIS data (aisstream.io)
-ACLED_EMAIL=               # Armed Conflict Location & Event Data (acleddata.com/user/register)
-ACLED_PASSWORD=            # OAuth2 password grant (API keys deprecated Sept 2025)
+
+# Federal Reserve Economic Data (free: fred.stlouisfed.org/docs/api)
+FRED_API_KEY=
+# NASA FIRMS fire data (free: firms.modaps.eosdis.nasa.gov/api)
+FIRMS_MAP_KEY=
+# Energy Information Administration (free: api.eia.gov/register)
+EIA_API_KEY=
+# Maritime AIS data (aisstream.io)
+AISSTREAM_API_KEY=
+# Armed Conflict Location & Event Data (acleddata.com/user/register)
+ACLED_EMAIL=
+# OAuth2 password grant (API keys deprecated Sept 2025)
+ACLED_PASSWORD=
 
 # === Server Configuration ===
-PORT=3117                          # Dashboard server port
-REFRESH_INTERVAL_MINUTES=15        # Auto-refresh interval (minutes)
+
+# Dashboard server port
+PORT=3117
+# Auto-refresh interval (minutes)
+REFRESH_INTERVAL_MINUTES=15
 
 # === LLM Layer (optional) ===
 # Enables AI-enhanced trade ideas and breaking news Telegram alerts.
 # Provider options: anthropic | openai | gemini | codex
 LLM_PROVIDER=
-LLM_API_KEY=               # Not needed for codex (uses ~/.codex/auth.json)
-LLM_MODEL=                 # Optional override. Each provider has a sensible default (claude-sonnet-4-6 / gpt-5.4 / gemini-3.1-pro / gpt-5.3-codex)
+# Not needed for codex (uses ~/.codex/auth.json)
+LLM_API_KEY=
+# Optional override. Each provider has a sensible default:
+# anthropic: claude-sonnet-4-6 | openai: gpt-5.4 | gemini: gemini-3.1-pro | codex: gpt-5.3-codex
+LLM_MODEL=
 
 # === Telegram Alerts (optional, requires LLM) ===
 # Create a bot via @BotFather, get chat ID via @userinfobot


### PR DESCRIPTION
## Summary
- Docker's `env_file` does not support inline comments — everything after `=` is treated as the value
- This caused `LLM_MODEL` (and potentially other vars) to include the comment text as their value, e.g. `# Optional override. Each provider has a sensible default (...)`
- The Anthropic API returned 404 because it received the comment string as the model name
- Moved all comments to their own lines above each variable
- Added a warning about this Docker behavior at the top of the file

## Test plan
- [ ] Copy `.env.example` to `.env`, fill in keys, and run via `docker compose up`
- [ ] Verify `LLM_MODEL` defaults correctly (no comment text in logs)