### PR TITLE
feat: add MiniMax as LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,12 +31,12 @@ REFRESH_INTERVAL_MINUTES=15
 
 # === LLM Layer (optional) ===
 # Enables AI-enhanced trade ideas and breaking news Telegram alerts.
-# Provider options: anthropic | openai | gemini | codex
+# Provider options: anthropic | openai | gemini | codex | minimax
 LLM_PROVIDER=
 # Not needed for codex (uses ~/.codex/auth.json)
 LLM_API_KEY=
 # Optional override. Each provider has a sensible default:
-# anthropic: claude-sonnet-4-6 | openai: gpt-5.4 | gemini: gemini-3.1-pro | codex: gpt-5.3-codex
+# anthropic: claude-sonnet-4-6 | openai: gpt-5.4 | gemini: gemini-3.1-pro | codex: gpt-5.3-codex | minimax: MiniMax-M2.5
 LLM_MODEL=
 
 # === Telegram Alerts (optional, requires LLM) ===

--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ Alerts are delivered as rich embeds with color-coded sidebars: red for FLASH, ye
 **Optional dependency:** The full bot requires `discord.js`. Install it with `npm install discord.js`. If it's not installed, Crucix automatically falls back to webhook-only mode.
 
 ### Optional LLM Layer
-Connect any of 4 LLM providers for enhanced analysis:
+Connect any of 5 LLM providers for enhanced analysis:
 - **AI trade ideas** — quantitative analyst producing 5-8 actionable ideas citing specific data
 - **Smarter alert evaluation** — LLM classifies signals into FLASH/PRIORITY/ROUTINE tiers with cross-domain correlation and confidence scoring
-- Providers: Anthropic Claude, OpenAI, Google Gemini, OpenAI Codex (ChatGPT subscription)
+- Providers: Anthropic Claude, OpenAI, Google Gemini, OpenAI Codex (ChatGPT subscription), MiniMax
 - Graceful fallback — when LLM is unavailable, a rule-based engine takes over alert evaluation. LLM failures never crash the sweep cycle.
 
 ---
@@ -184,7 +184,7 @@ These three unlock the most valuable economic and satellite data. Each takes abo
 
 ### LLM Provider (optional, for AI-enhanced ideas)
 
-Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`
+Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `minimax`
 
 | Provider | Key Required | Default Model |
 |----------|-------------|---------------|
@@ -192,6 +192,7 @@ Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`
 | `openai` | `LLM_API_KEY` | gpt-5.4 |
 | `gemini` | `LLM_API_KEY` | gemini-3.1-pro |
 | `codex` | None (uses `~/.codex/auth.json`) | gpt-5.3-codex |
+| `minimax` | `LLM_API_KEY` | MiniMax-M2.5 |
 
 For Codex, run `npx @openai/codex login` to authenticate via your ChatGPT subscription.
 
@@ -261,12 +262,13 @@ crucix/
 │       └── jarvis.html        # Self-contained Jarvis HUD
 │
 ├── lib/
-│   ├── llm/                   # LLM abstraction (4 providers, raw fetch, no SDKs)
+│   ├── llm/                   # LLM abstraction (5 providers, raw fetch, no SDKs)
 │   │   ├── provider.mjs       # Base class
 │   │   ├── anthropic.mjs      # Claude
 │   │   ├── openai.mjs         # GPT
 │   │   ├── gemini.mjs         # Gemini
 │   │   ├── codex.mjs          # Codex (ChatGPT subscription)
+│   │   ├── minimax.mjs        # MiniMax (M2.5, 204K context)
 │   │   ├── ideas.mjs          # LLM-powered trade idea generation
 │   │   └── index.mjs          # Factory: createLLMProvider()
 │   ├── delta/                 # Change tracking between sweeps
@@ -368,7 +370,7 @@ All settings are in `.env` with sensible defaults:
 |----------|---------|-------------|
 | `PORT` | `3117` | Dashboard server port |
 | `REFRESH_INTERVAL_MINUTES` | `15` | Auto-refresh interval |
-| `LLM_PROVIDER` | disabled | `anthropic`, `openai`, `gemini`, or `codex` |
+| `LLM_PROVIDER` | disabled | `anthropic`, `openai`, `gemini`, `codex`, or `minimax` |
 | `LLM_API_KEY` | — | API key (not needed for codex) |
 | `LLM_MODEL` | per-provider default | Override model selection |
 | `TELEGRAM_BOT_TOKEN` | disabled | For Telegram alerts + bot commands |

--- a/crucix.config.mjs
+++ b/crucix.config.mjs
@@ -7,7 +7,7 @@ export default {
   refreshIntervalMinutes: parseInt(process.env.REFRESH_INTERVAL_MINUTES) || 15,
 
   llm: {
-    provider: process.env.LLM_PROVIDER || null, // anthropic | openai | gemini | codex
+    provider: process.env.LLM_PROVIDER || null, // anthropic | openai | gemini | codex | minimax
     apiKey: process.env.LLM_API_KEY || null,
     model: process.env.LLM_MODEL || null,
   },

--- a/lib/llm/index.mjs
+++ b/lib/llm/index.mjs
@@ -4,12 +4,14 @@ import { AnthropicProvider } from './anthropic.mjs';
 import { OpenAIProvider } from './openai.mjs';
 import { GeminiProvider } from './gemini.mjs';
 import { CodexProvider } from './codex.mjs';
+import { MiniMaxProvider } from './minimax.mjs';
 
 export { LLMProvider } from './provider.mjs';
 export { AnthropicProvider } from './anthropic.mjs';
 export { OpenAIProvider } from './openai.mjs';
 export { GeminiProvider } from './gemini.mjs';
 export { CodexProvider } from './codex.mjs';
+export { MiniMaxProvider } from './minimax.mjs';
 
 /**
  * Create an LLM provider based on config.
@@ -30,6 +32,8 @@ export function createLLMProvider(llmConfig) {
       return new GeminiProvider({ apiKey, model });
     case 'codex':
       return new CodexProvider({ model });
+    case 'minimax':
+      return new MiniMaxProvider({ apiKey, model });
     default:
       console.warn(`[LLM] Unknown provider "${provider}". LLM features disabled.`);
       return null;

--- a/lib/llm/minimax.mjs
+++ b/lib/llm/minimax.mjs
@@ -1,0 +1,51 @@
+// MiniMax Provider — raw fetch, no SDK
+// Uses MiniMax's OpenAI-compatible Chat Completions API
+
+import { LLMProvider } from './provider.mjs';
+
+export class MiniMaxProvider extends LLMProvider {
+  constructor(config) {
+    super(config);
+    this.name = 'minimax';
+    this.apiKey = config.apiKey;
+    this.model = config.model || 'MiniMax-M2.5';
+  }
+
+  get isConfigured() { return !!this.apiKey; }
+
+  async complete(systemPrompt, userMessage, opts = {}) {
+    const res = await fetch('https://api.minimax.io/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.model,
+        max_tokens: opts.maxTokens || 4096,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userMessage },
+        ],
+      }),
+      signal: AbortSignal.timeout(opts.timeout || 60000),
+    });
+
+    if (!res.ok) {
+      const err = await res.text().catch(() => '');
+      throw new Error(`MiniMax API ${res.status}: ${err.substring(0, 200)}`);
+    }
+
+    const data = await res.json();
+    const text = data.choices?.[0]?.message?.content || '';
+
+    return {
+      text,
+      usage: {
+        inputTokens: data.usage?.prompt_tokens || 0,
+        outputTokens: data.usage?.completion_tokens || 0,
+      },
+      model: data.model || this.model,
+    };
+  }
+}

--- a/test/llm-minimax-integration.test.mjs
+++ b/test/llm-minimax-integration.test.mjs
@@ -1,0 +1,30 @@
+// MiniMax provider — integration test (calls real API)
+// Requires MINIMAX_API_KEY environment variable
+// Run: MINIMAX_API_KEY=sk-... node --test test/llm-minimax-integration.test.mjs
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { MiniMaxProvider } from '../lib/llm/minimax.mjs';
+
+const API_KEY = process.env.MINIMAX_API_KEY;
+
+describe('MiniMax integration', { skip: !API_KEY && 'MINIMAX_API_KEY not set' }, () => {
+  it('should complete a prompt with MiniMax-M2.5', async () => {
+    const provider = new MiniMaxProvider({ apiKey: API_KEY, model: 'MiniMax-M2.5' });
+    assert.equal(provider.isConfigured, true);
+
+    const result = await provider.complete(
+      'You are a helpful assistant. Respond in exactly one sentence.',
+      'What is 2+2?',
+      { maxTokens: 128, timeout: 30000 }
+    );
+
+    assert.ok(result.text.length > 0, 'Response text should not be empty');
+    assert.ok(result.usage.inputTokens > 0, 'Should report input tokens');
+    assert.ok(result.usage.outputTokens > 0, 'Should report output tokens');
+    assert.ok(result.model, 'Should report model name');
+    console.log(`  Response: ${result.text}`);
+    console.log(`  Tokens: ${result.usage.inputTokens} in / ${result.usage.outputTokens} out`);
+    console.log(`  Model: ${result.model}`);
+  });
+});

--- a/test/llm-minimax.test.mjs
+++ b/test/llm-minimax.test.mjs
@@ -1,0 +1,144 @@
+// MiniMax provider — unit tests
+// Uses Node.js built-in test runner (node:test) — no extra dependencies
+
+import { describe, it, mock, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { MiniMaxProvider } from '../lib/llm/minimax.mjs';
+import { createLLMProvider } from '../lib/llm/index.mjs';
+
+// ─── Unit Tests ───
+
+describe('MiniMaxProvider', () => {
+  it('should set defaults correctly', () => {
+    const provider = new MiniMaxProvider({ apiKey: 'sk-test' });
+    assert.equal(provider.name, 'minimax');
+    assert.equal(provider.model, 'MiniMax-M2.5');
+    assert.equal(provider.isConfigured, true);
+  });
+
+  it('should accept custom model', () => {
+    const provider = new MiniMaxProvider({ apiKey: 'sk-test', model: 'MiniMax-M2.5-highspeed' });
+    assert.equal(provider.model, 'MiniMax-M2.5-highspeed');
+  });
+
+  it('should report not configured without API key', () => {
+    const provider = new MiniMaxProvider({});
+    assert.equal(provider.isConfigured, false);
+  });
+
+  it('should throw on API error', async () => {
+    const provider = new MiniMaxProvider({ apiKey: 'sk-test' });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(() =>
+      Promise.resolve({ ok: false, status: 401, text: () => Promise.resolve('Unauthorized') })
+    );
+    try {
+      await assert.rejects(
+        () => provider.complete('system', 'user'),
+        (err) => {
+          assert.match(err.message, /MiniMax API 401/);
+          return true;
+        }
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should parse successful response', async () => {
+    const provider = new MiniMaxProvider({ apiKey: 'sk-test' });
+    const mockResponse = {
+      choices: [{ message: { content: 'Hello from MiniMax' } }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+      model: 'MiniMax-M2.5',
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+    );
+    try {
+      const result = await provider.complete('You are helpful.', 'Say hello');
+      assert.equal(result.text, 'Hello from MiniMax');
+      assert.equal(result.usage.inputTokens, 10);
+      assert.equal(result.usage.outputTokens, 5);
+      assert.equal(result.model, 'MiniMax-M2.5');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should send correct request format', async () => {
+    const provider = new MiniMaxProvider({ apiKey: 'sk-test-key', model: 'MiniMax-M2.5' });
+    let capturedUrl, capturedOpts;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn((url, opts) => {
+      capturedUrl = url;
+      capturedOpts = opts;
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'ok' } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+          model: 'MiniMax-M2.5',
+        }),
+      });
+    });
+    try {
+      await provider.complete('system prompt', 'user message', { maxTokens: 2048 });
+      assert.equal(capturedUrl, 'https://api.minimax.io/v1/chat/completions');
+      assert.equal(capturedOpts.method, 'POST');
+      const headers = capturedOpts.headers;
+      assert.equal(headers['Content-Type'], 'application/json');
+      assert.equal(headers['Authorization'], 'Bearer sk-test-key');
+      const body = JSON.parse(capturedOpts.body);
+      assert.equal(body.model, 'MiniMax-M2.5');
+      assert.equal(body.max_tokens, 2048);
+      assert.equal(body.messages[0].role, 'system');
+      assert.equal(body.messages[0].content, 'system prompt');
+      assert.equal(body.messages[1].role, 'user');
+      assert.equal(body.messages[1].content, 'user message');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should handle empty response gracefully', async () => {
+    const provider = new MiniMaxProvider({ apiKey: 'sk-test' });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ choices: [], usage: {} }),
+      })
+    );
+    try {
+      const result = await provider.complete('sys', 'user');
+      assert.equal(result.text, '');
+      assert.equal(result.usage.inputTokens, 0);
+      assert.equal(result.usage.outputTokens, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ─── Factory Tests ───
+
+describe('createLLMProvider — minimax', () => {
+  it('should create MiniMaxProvider for provider=minimax', () => {
+    const provider = createLLMProvider({ provider: 'minimax', apiKey: 'sk-test', model: null });
+    assert.ok(provider instanceof MiniMaxProvider);
+    assert.equal(provider.name, 'minimax');
+    assert.equal(provider.isConfigured, true);
+  });
+
+  it('should be case-insensitive', () => {
+    const provider = createLLMProvider({ provider: 'MiniMax', apiKey: 'sk-test', model: null });
+    assert.ok(provider instanceof MiniMaxProvider);
+  });
+
+  it('should return null for empty provider', () => {
+    const provider = createLLMProvider({ provider: null, apiKey: 'sk-test', model: null });
+    assert.equal(provider, null);
+  });
+});


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimaxi.com/) as a fifth LLM provider for Crucix's intelligence analysis layer.

MiniMax offers an OpenAI-compatible Chat Completions API with the **M2.5 model** (204K context window), making it a strong fit for processing the large OSINT data sweeps that Crucix generates.

### Changes

- **`lib/llm/minimax.mjs`** — new provider class using raw `fetch()` (no SDK, consistent with existing providers)
- **`lib/llm/index.mjs`** — register `minimax` in the `createLLMProvider()` factory
- **`.env.example`** — add `minimax` to the provider options list
- **`crucix.config.mjs`** — update config comment
- **`README.md`** — document MiniMax in LLM provider tables and architecture tree
- **`test/llm-minimax.test.mjs`** — 10 unit tests using `node:test` (constructor, config, request format, error handling, factory)
- **`test/llm-minimax-integration.test.mjs`** — live API integration test (skipped when `MINIMAX_API_KEY` not set)

### Usage

```env
LLM_PROVIDER=minimax
LLM_API_KEY=sk-...
LLM_MODEL=MiniMax-M2.5          # optional, this is the default
```

### Test Results

```
# Unit tests: 10/10 pass
# Integration test: 1/1 pass (verified against live MiniMax API)
```

## Test plan

- [x] Unit tests pass: `node --test test/llm-minimax.test.mjs`
- [x] Integration test passes with real API key: `MINIMAX_API_KEY=sk-... node --test test/llm-minimax-integration.test.mjs`
- [x] Existing providers unaffected (no changes to their code)
- [ ] Verify `npm run dev` with `LLM_PROVIDER=minimax` generates trade ideas
