### PR TITLE
feat(llm): add Cursor provider via cursor-api-proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ REFRESH_INTERVAL_MINUTES=15
 
 # === LLM Layer (optional) ===
 # Enables AI-enhanced trade ideas and breaking news Telegram alerts.
-# Provider options: anthropic | openai | gemini | codex | openrouter | minimax | mistral | ollama | grok
+# Provider options: anthropic | openai | gemini | codex | openrouter | minimax | mistral | ollama | grok | cursor
 LLM_PROVIDER=
 # Not needed for codex (uses ~/.codex/auth.json) or ollama (local)
 LLM_API_KEY=
@@ -42,6 +42,8 @@ LLM_API_KEY=
 LLM_MODEL=
 # Ollama base URL (only needed if not using default http://localhost:11434)
 OLLAMA_BASE_URL=
+# For cursor: proxy URL (optional; default auto-starts on 127.0.0.1:8765)
+LLM_CURSOR_BASE_URL=
 
 # === Telegram Alerts (optional, requires LLM) ===
 # Create a bot via @BotFather, get chat ID via @userinfobot

--- a/README.md
+++ b/README.md
@@ -186,10 +186,10 @@ Alerts are delivered as rich embeds with color-coded sidebars: red for FLASH, ye
 **Optional dependency:** The full bot requires `discord.js`. Install it with `npm install discord.js`. If it's not installed, Crucix automatically falls back to webhook-only mode.
 
 ### Optional LLM Layer
-Connect any of 8 LLM providers for enhanced analysis:
+Connect any of 9 LLM providers for enhanced analysis:
 - **AI trade ideas** — quantitative analyst producing 5-8 actionable ideas citing specific data
 - **Smarter alert evaluation** — LLM classifies signals into FLASH/PRIORITY/ROUTINE tiers with cross-domain correlation and confidence scoring
-- Providers: Anthropic Claude, OpenAI, Google Gemini, OpenRouter (Unified API), OpenAI Codex (ChatGPT subscription), MiniMax, Mistral, Grok
+- Providers: Anthropic Claude, OpenAI, Google Gemini, OpenRouter (Unified API), OpenAI Codex (ChatGPT subscription), MiniMax, Mistral, Grok, [Cursor (via cursor-api-proxy)](https://www.npmjs.com/package/cursor-api-proxy)
 - Graceful fallback — when LLM is unavailable, a rule-based engine takes over alert evaluation. LLM failures never crash the sweep cycle.
 
 ---
@@ -222,7 +222,7 @@ These three unlock the most valuable economic and satellite data. Each takes abo
 
 ### LLM Provider (optional, for AI-enhanced ideas)
 
-Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, `grok`
+Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, `grok`, `cursor`
 
 | Provider | Key Required | Default Model |
 |----------|-------------|---------------|
@@ -234,6 +234,9 @@ Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `openrou
 | `minimax` | `LLM_API_KEY` | MiniMax-M2.5 |
 | `mistral` | `LLM_API_KEY` | mistral-large-latest |
 | `grok` | `LLM_API_KEY` | grok-4-latest |
+| `cursor` | Optional (if proxy uses `CURSOR_BRIDGE_API_KEY`) | auto (proxy auto-starts on first use) |
+
+**Cursor setup:** Uses the [cursor-api-proxy](https://www.npmjs.com/package/cursor-api-proxy) dependency. (1) Install and log in to the Cursor agent CLI (`curl https://cursor.com/install -fsS | bash`, then `agent login`). (2) Set `LLM_PROVIDER=cursor`. (3) No need to run the proxy separately — it starts automatically on first use. (4) Optional: `LLM_CURSOR_BASE_URL` if you run the proxy elsewhere; `LLM_API_KEY` if the proxy requires auth; `LLM_MODEL` (e.g. `gpt-5.2`) to override the default model.
 
 For Codex, run `npx @openai/codex login` to authenticate via your ChatGPT subscription.
 
@@ -303,16 +306,17 @@ crucix/
 │       └── jarvis.html        # Self-contained Jarvis HUD
 │
 ├── lib/
-│   ├── llm/                   # LLM abstraction (8 providers, raw fetch, no SDKs)
+│   ├── llm/                   # LLM abstraction (9 providers, raw fetch + cursor-api-proxy SDK)
 │   │   ├── provider.mjs       # Base class
 │   │   ├── anthropic.mjs      # Claude
 │   │   ├── openai.mjs         # GPT
 │   │   ├── gemini.mjs         # Gemini
-│   │   ├── grok.mjs           # Grok
 │   │   ├── openrouter.mjs     # OpenRouter (Unified API)
 │   │   ├── codex.mjs          # Codex (ChatGPT subscription)
 │   │   ├── minimax.mjs        # MiniMax (M2.5, 204K context)
 │   │   ├── mistral.mjs        # Mistral AI
+│   │   ├── grok.mjs           # Grok
+│   │   ├── cursor.mjs         # Cursor (cursor-api-proxy, auto-starts proxy)
 │   │   ├── ideas.mjs          # LLM-powered trade idea generation
 │   │   └── index.mjs          # Factory: createLLMProvider()
 │   ├── delta/                 # Change tracking between sweeps
@@ -330,7 +334,7 @@ crucix/
 
 ### Design Principles
 - **Pure ESM** — every file is `.mjs` with explicit imports
-- **Minimal dependencies** — Express is the only runtime dependency. `discord.js` is optional (for Discord bot). LLM providers use raw `fetch()`, no SDKs.
+- **Minimal dependencies** — Express and optional `cursor-api-proxy` (for Cursor provider). `discord.js` is optional (for Discord bot). LLM providers use raw `fetch()` or the cursor-api-proxy SDK.
 - **Parallel execution** — `Promise.allSettled()` fires all 27 sources simultaneously
 - **Graceful degradation** — missing keys produce errors, not crashes. LLM failures don't kill sweeps.
 - **Each source is standalone** — run `node apis/sources/gdelt.mjs` to test any source independently
@@ -414,9 +418,10 @@ All settings are in `.env` with sensible defaults:
 |----------|---------|-------------|
 | `PORT` | `3117` | Dashboard server port |
 | `REFRESH_INTERVAL_MINUTES` | `15` | Auto-refresh interval |
-| `LLM_PROVIDER` | disabled | `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, or `grok` |
-| `LLM_API_KEY` | — | API key (not needed for codex) |
+| `LLM_PROVIDER` | disabled | `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, `grok`, or `cursor` |
+| `LLM_API_KEY` | — | API key (not needed for codex; optional for cursor) |
 | `LLM_MODEL` | per-provider default | Override model selection |
+| `LLM_CURSOR_BASE_URL` | — | For cursor: proxy URL (optional; default auto-starts on 127.0.0.1:8765) |
 | `TELEGRAM_BOT_TOKEN` | disabled | For Telegram alerts + bot commands |
 | `TELEGRAM_CHAT_ID` | — | Your Telegram chat ID |
 | `TELEGRAM_CHANNELS` | — | Extra channel IDs to monitor (comma-separated) |

--- a/crucix.config.mjs
+++ b/crucix.config.mjs
@@ -7,9 +7,10 @@ export default {
   refreshIntervalMinutes: parseInt(process.env.REFRESH_INTERVAL_MINUTES) || 15,
 
   llm: {
-    provider: process.env.LLM_PROVIDER || null, // anthropic | openai | gemini | codex | openrouter | minimax | mistral | ollama | grok
+    provider: process.env.LLM_PROVIDER || null, // anthropic | openai | gemini | codex | openrouter | minimax | mistral | ollama | grok | cursor
     apiKey: process.env.LLM_API_KEY || null,
     model: process.env.LLM_MODEL || null,
+    cursorBaseUrl: process.env.LLM_CURSOR_BASE_URL || null,
     baseUrl: process.env.OLLAMA_BASE_URL || null,
   },
 

--- a/lib/llm/cursor.mjs
+++ b/lib/llm/cursor.mjs
@@ -1,0 +1,60 @@
+// Cursor Provider — uses cursor-api-proxy SDK (proxy auto-starts on first use)
+
+import { LLMProvider } from './provider.mjs';
+import { createCursorProxyClient } from 'cursor-api-proxy';
+
+export class CursorProvider extends LLMProvider {
+  constructor(config) {
+    super(config);
+    this.name = 'cursor';
+    this.baseUrl = config.baseUrl ?? process.env.LLM_CURSOR_BASE_URL ?? undefined;
+    this.apiKey = config.apiKey ?? process.env.LLM_API_KEY ?? undefined;
+    this.model = config.model ?? process.env.LLM_MODEL ?? 'auto';
+    this._client = null;
+  }
+
+  get isConfigured() {
+    return true;
+  }
+
+  _getClient() {
+    if (!this._client) {
+      this._client = createCursorProxyClient({
+        baseUrl: this.baseUrl,
+        apiKey: this.apiKey,
+        startProxy: !this.baseUrl,
+      });
+    }
+    return this._client;
+  }
+
+  async complete(systemPrompt, userMessage, opts = {}) {
+    const client = this._getClient();
+    try {
+      const data = await client.chatCompletionsCreate({
+        model: this.model,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userMessage },
+        ],
+      });
+
+      if (data.error?.message) {
+        throw new Error(data.error.message);
+      }
+
+      const text = data.choices?.[0]?.message?.content ?? '';
+      const usage = data.usage ?? {};
+      return {
+        text,
+        usage: {
+          inputTokens: usage.prompt_tokens ?? 0,
+          outputTokens: usage.completion_tokens ?? 0,
+        },
+        model: data.model ?? this.model,
+      };
+    } catch (err) {
+      throw new Error(`Cursor proxy: ${err.message}`);
+    }
+  }
+}

--- a/lib/llm/index.mjs
+++ b/lib/llm/index.mjs
@@ -9,6 +9,7 @@ import { MiniMaxProvider } from "./minimax.mjs";
 import { MistralProvider } from "./mistral.mjs";
 import { OllamaProvider } from "./ollama.mjs";
 import { GrokProvider } from "./grok.mjs";
+import { CursorProvider } from "./cursor.mjs";
 
 export { LLMProvider } from "./provider.mjs";
 export { AnthropicProvider } from "./anthropic.mjs";
@@ -20,16 +21,17 @@ export { MiniMaxProvider } from "./minimax.mjs";
 export { MistralProvider } from "./mistral.mjs";
 export { OllamaProvider } from "./ollama.mjs";
 export { GrokProvider } from "./grok.mjs";
+export { CursorProvider } from "./cursor.mjs";
 
 /**
  * Create an LLM provider based on config.
- * @param {{ provider: string|null, apiKey: string|null, model: string|null }} llmConfig
+ * @param {{ provider: string|null, apiKey: string|null, model: string|null, cursorBaseUrl: string|null }} llmConfig
  * @returns {LLMProvider|null}
  */
 export function createLLMProvider(llmConfig) {
   if (!llmConfig?.provider) return null;
 
-  const { provider, apiKey, model } = llmConfig;
+  const { provider, apiKey, model, cursorBaseUrl } = llmConfig;
 
   switch (provider.toLowerCase()) {
     case "anthropic":
@@ -42,13 +44,15 @@ export function createLLMProvider(llmConfig) {
       return new GeminiProvider({ apiKey, model });
     case "codex":
       return new CodexProvider({ model });
+    case "cursor":
+      return new CursorProvider({ baseUrl: cursorBaseUrl, apiKey, model });
     case "minimax":
       return new MiniMaxProvider({ apiKey, model });
     case "mistral":
       return new MistralProvider({ apiKey, model });
     case "ollama":
       return new OllamaProvider({ model, baseUrl: llmConfig.baseUrl });
-    case 'grok':
+    case "grok":
       return new GrokProvider({ apiKey, model });
     default:
       console.warn(

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "brief:save": "node apis/save-briefing.mjs",
     "diag": "node diag.mjs",
     "clean": "node scripts/clean.mjs",
-    "fresh-start": "npm run clean && npm start"
+    "fresh-start": "npm run clean && npm start",
+    "test": "node --test test/",
+    "test:cursor-integration": "node --test test/llm-cursor-integration.test.mjs"
   },
   "keywords": [
     "osint",
@@ -27,6 +29,7 @@
     "npm": ">=10"
   },
   "dependencies": {
+    "cursor-api-proxy": "^0.4.0",
     "express": "^5.1.0"
   },
   "optionalDependencies": {

--- a/test/llm-cursor-integration.test.mjs
+++ b/test/llm-cursor-integration.test.mjs
@@ -1,0 +1,27 @@
+// Integration test for Cursor LLM provider (requires Cursor CLI + proxy)
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createLLMProvider } from '../lib/llm/index.mjs';
+
+const skip = process.env.LLM_PROVIDER !== 'cursor';
+
+test('CursorProvider integration test', { skip }, async (t) => {
+  await t.test('performs live API call', async () => {
+    const provider = createLLMProvider({
+      provider: 'cursor',
+      apiKey: process.env.LLM_API_KEY || null,
+      model: process.env.LLM_MODEL || 'auto',
+    });
+
+    const result = await provider.complete(
+      'Reply with exactly "Hello".',
+      'Hi'
+    );
+    assert.ok(result.text.length > 0, 'Should return text');
+    assert.ok(
+      result.usage.inputTokens >= 0 && result.usage.outputTokens >= 0,
+      'Should return usage'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Adds a sixth LLM provider, `cursor`, using the [cursor-api-proxy](https://www.npmjs.com/package/cursor-api-proxy) npm package. The proxy starts in the background on first request when using the default URL—no separate process or manual `npx cursor-api-proxy` needed.

## Changes
- **Dependency:** `cursor-api-proxy` in `dependencies`
- **New:** `lib/llm/cursor.mjs` — `CursorProvider` using `createCursorProxyClient()`, optional `baseUrl` / `apiKey` / `model`
- **Config:** `cursor` case in `createLLMProvider`, `cursorBaseUrl` in `crucix.config.mjs`
- **Docs:** `.env.example` and README updated (provider list, Cursor setup, `LLM_CURSOR_BASE_URL`)
- **Test:** `test/llm-cursor-integration.test.mjs` (skipped unless `LLM_PROVIDER=cursor`)

## Setup
1. `npm install` (installs cursor-api-proxy)
2. Install Cursor agent CLI and run `agent login`
3. Set `LLM_PROVIDER=cursor` in `.env`
4. Optional: `LLM_CURSOR_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL`