### PR TITLE
feat(llm): add support for custom OpenAI-compatible API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,10 @@ LLM_API_KEY=
 # anthropic: claude-sonnet-4-6 | openai: gpt-5.4 | gemini: gemini-3.1-pro | codex: gpt-5.3-codex
 LLM_MODEL=
 
+# Optional override. Defaults to OpenAI's API endpoint.
+LLM_BASE_URL=
+
+
 # === Telegram Alerts (optional, requires LLM) ===
 # Create a bot via @BotFather, get chat ID via @userinfobot
 TELEGRAM_BOT_TOKEN=

--- a/crucix.config.mjs
+++ b/crucix.config.mjs
@@ -10,6 +10,7 @@ export default {
     provider: process.env.LLM_PROVIDER || null, // anthropic | openai | gemini | codex
     apiKey: process.env.LLM_API_KEY || null,
     model: process.env.LLM_MODEL || null,
+    baseUrl: process.env.LLM_BASE_URL || null, // custom base URL for OpenAI-compatible APIs
   },
 
   telegram: {

--- a/lib/llm/index.mjs
+++ b/lib/llm/index.mjs
@@ -19,13 +19,13 @@ export { CodexProvider } from './codex.mjs';
 export function createLLMProvider(llmConfig) {
   if (!llmConfig?.provider) return null;
 
-  const { provider, apiKey, model } = llmConfig;
+  const { provider, apiKey, model, baseUrl } = llmConfig;
 
   switch (provider.toLowerCase()) {
     case 'anthropic':
       return new AnthropicProvider({ apiKey, model });
     case 'openai':
-      return new OpenAIProvider({ apiKey, model });
+      return new OpenAIProvider({ apiKey, model, baseUrl });
     case 'gemini':
       return new GeminiProvider({ apiKey, model });
     case 'codex':

--- a/lib/llm/openai.mjs
+++ b/lib/llm/openai.mjs
@@ -8,12 +8,13 @@ export class OpenAIProvider extends LLMProvider {
     this.name = 'openai';
     this.apiKey = config.apiKey;
     this.model = config.model || 'gpt-5.4';
+    this.baseUrl = config.baseUrl || 'https://api.openai.com/v1';
   }
 
   get isConfigured() { return !!this.apiKey; }
 
   async complete(systemPrompt, userMessage, opts = {}) {
-    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    const res = await fetch(this.baseUrl + '/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
This pull request adds support for customizing the base URL used by the OpenAI provider, allowing integration with OpenAI-compatible APIs hosted at non-default endpoints. The main changes involve updating configuration files and refactoring the provider initialization logic to use the new `baseUrl` parameter.

Configuration enhancements:

* Added an optional `LLM_BASE_URL` environment variable to `.env.example` to allow overriding the default OpenAI API endpoint.
* Updated `crucix.config.mjs` to read the `baseUrl` value from the environment, making it configurable for the LLM provider.

Provider logic updates:

* Modified `createLLMProvider` in `lib/llm/index.mjs` to pass the `baseUrl` parameter to the OpenAI provider when initializing.
* Updated the `OpenAIProvider` class in `lib/llm/openai.mjs` to use the configurable `baseUrl` for API requests, defaulting to `https://api.openai.com/v1` if not specified.