### PR TITLE
Fix Al Jazeera RSS feed URL

### DIFF
--- a/dashboard/inject.mjs
+++ b/dashboard/inject.mjs
@@ -125,7 +125,7 @@ export async function fetchAllNews() {
   const feeds = [
     ['http://feeds.bbci.co.uk/news/world/rss.xml', 'BBC'],
     ['https://rss.nytimes.com/services/xml/rss/nyt/World.xml', 'NYT'],
-    ['https://feeds.aljazeera.com/xml/rss/all.xml', 'Al Jazeera'],
+    ['https://www.aljazeera.com/xml/rss/all.xml', 'Al Jazeera'],
     ['https://rss.nytimes.com/services/xml/rss/nyt/Americas.xml', 'NYT Americas'],
     ['https://rss.nytimes.com/services/xml/rss/nyt/AsiaPacific.xml', 'NYT Asia'],
     ['https://feeds.bbci.co.uk/news/technology/rss.xml', 'BBC Tech'],


### PR DESCRIPTION
## Summary

Output when running sweep includes `RSS fetch failed (Al Jazeera): fetch failed` (even though there was no failure count in the health endpoint, which may be a bug), and missing Al Jazeera articles in news ticker.

## Why

The old RSS feed was hosted on `feeds.aljazeera.com` which no longer resolves. The current RSS feeds are on  `www.aljazeera.com`.

## Scope

- [x] Focused bug fix
- [ ] Small UX improvement
- [ ] New source
- [ ] Dashboard change
- [ ] Docs/config change

## Validation

Restarted and verified that articles are present in the news ticker.

## Checklist

- [x] This PR stays within one bugfix or one feature family
- [x] I kept unrelated changes out of the diff
- [x] I considered security for any mixed-source content rendering
- [x] I tested the changed path locally
