### PR TITLE
Fix telegram

### DIFF
--- a/lib/alerts/telegram.mjs
+++ b/lib/alerts/telegram.mjs
@@ -4,6 +4,8 @@
 import { createHash } from 'crypto';
 
 const TELEGRAM_API = 'https://api.telegram.org';
+/** Telegram Bot API limit for sendMessage text (bytes/characters). */
+const TELEGRAM_MAX_TEXT = 4096;
 
 // ─── Alert Tiers ────────────────────────────────────────────────────────────
 // FLASH:    Immediate action required — market-moving, time-critical (e.g. war escalation, flash crash)
@@ -48,40 +50,68 @@ export class TelegramAlerter {
   // ─── Core Messaging ─────────────────────────────────────────────────────
 
   /**
-   * Send a message via Telegram Bot API.
+   * Send a message via Telegram Bot API. Splits at TELEGRAM_MAX_TEXT so long messages
+   * (e.g. /brief) are sent in multiple messages instead of being truncated or failing.
    * @param {string} message - markdown-formatted message
-   * @param {object} opts - optional: { parseMode, disablePreview, replyToMessageId }
+   * @param {object} opts - optional: { parseMode, disablePreview, replyToMessageId, chatId }
    * @returns {Promise<{ok: boolean, messageId?: number}>}
    */
   async sendMessage(message, opts = {}) {
     if (!this.isConfigured) return { ok: false };
+    const chatId = opts.chatId ?? this.chatId;
+    const parseMode = opts.parseMode || 'Markdown';
+    const chunks = this._chunkText(message, TELEGRAM_MAX_TEXT);
 
     try {
-      const res = await fetch(`${TELEGRAM_API}/bot${this.botToken}/sendMessage`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          chat_id: opts.chatId ?? this.chatId,
-          text: message,
-          parse_mode: opts.parseMode || 'Markdown',
-          disable_web_page_preview: opts.disablePreview !== false,
-          ...(opts.replyToMessageId ? { reply_to_message_id: opts.replyToMessageId } : {}),
-        }),
-        signal: AbortSignal.timeout(15000),
-      });
+      let lastResult = { ok: false, messageId: undefined };
+      for (let i = 0; i < chunks.length; i++) {
+        const res = await fetch(`${TELEGRAM_API}/bot${this.botToken}/sendMessage`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            chat_id: chatId,
+            text: chunks[i],
+            parse_mode: parseMode,
+            disable_web_page_preview: opts.disablePreview !== false,
+            ...(opts.replyToMessageId && i === 0 ? { reply_to_message_id: opts.replyToMessageId } : {}),
+          }),
+          signal: AbortSignal.timeout(15000),
+        });
 
-      if (!res.ok) {
-        const err = await res.text().catch(() => '');
-        console.error(`[Telegram] Send failed (${res.status}): ${err.substring(0, 200)}`);
-        return { ok: false };
+        if (!res.ok) {
+          const err = await res.text().catch(() => '');
+          console.error(`[Telegram] Send failed (${res.status}): ${err.substring(0, 200)}`);
+          return lastResult;
+        }
+
+        const data = await res.json();
+        lastResult = { ok: true, messageId: data.result?.message_id };
       }
-
-      const data = await res.json();
-      return { ok: true, messageId: data.result?.message_id };
+      return lastResult;
     } catch (err) {
       console.error('[Telegram] Send error:', err.message);
       return { ok: false };
     }
+  }
+
+  /**
+   * Split text into chunks of at most maxLen. Prefer breaking at newlines to avoid
+   * splitting mid-Markdown.
+   */
+  _chunkText(text, maxLen = TELEGRAM_MAX_TEXT) {
+    if (!text || text.length <= maxLen) return text ? [text] : [];
+    const chunks = [];
+    let start = 0;
+    while (start < text.length) {
+      let end = Math.min(start + maxLen, text.length);
+      if (end < text.length) {
+        const lastNewline = text.lastIndexOf('\n', end - 1);
+        if (lastNewline > start) end = lastNewline + 1;
+      }
+      chunks.push(text.slice(start, end));
+      start = end;
+    }
+    return chunks;
   }
 
   // Backward-compatible alias


### PR DESCRIPTION
## Summary

- **Telegram bot:** Slash commands are now registered with Telegram via `setMyCommands` so they appear in DMs and groups. Command replies go to the chat that sent the command (including DMs). Group commands like `/status@YourBot` are supported. Long messages (e.g. `/brief`) are split at 4096 characters and sent as multiple messages instead of being truncated or failing.

## Why

- Slash commands did not show in Telegram (DM or group) because the bot never called `setMyCommands`; the API was only used for sending alerts.
- Command replies were always sent to the configured alert `TELEGRAM_CHAT_ID`, so DMs and other groups never got a response.
- Messages longer than Telegram’s 4096‑char limit were either rejected by the API or cut off.

## Scope

- [x] Focused bug fix
- [x] Small UX improvement
- [ ] New source
- [ ] Dashboard change
- [ ] Docs/config change

## Validation

- Restarted server; saw `[Telegram] Bot command polling started` and no errors on `_initializeBotCommands()`.
- In Telegram: opened DM with bot and group — typed `/` and confirmed command list appears; sent `/status` and `/brief` in both; verified reply in same chat.
- Sent a `/brief` long enough to exceed 4096 chars; confirmed multiple messages received with no truncation.

## Screenshots

_Optional:_ Screenshot of Telegram chat with `/` showing the Crucix command list in the slash menu, and/or a long `/brief` split into two messages.

## Config and Docs

- [x] No new environment variables
- [ ] `.env.example` updated if needed
- [ ] `README.md` updated if behavior changed

## Source Additions

N/A.

## Checklist

- [x] This PR stays within one bugfix or one feature family
- [x] I kept unrelated changes out of the diff
- [x] I considered security for any mixed-source content rendering (Telegram: still only process commands from private or configured chat; replies go to sender chat only)
- [x] I tested the changed path locally