### PR TITLE
feat: add xAI Grok as LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,12 +31,12 @@ REFRESH_INTERVAL_MINUTES=15
 
 # === LLM Layer (optional) ===
 # Enables AI-enhanced trade ideas and breaking news Telegram alerts.
-# Provider options: anthropic | openai | gemini | codex | openrouter | minimax | mistral
+# Provider options: anthropic | openai | gemini | codex | openrouter | minimax | mistral | xai
 LLM_PROVIDER=
 # Not needed for codex (uses ~/.codex/auth.json)
 LLM_API_KEY=
 # Optional override. Each provider has a sensible default:
-# anthropic: claude-sonnet-4-6 | openai: gpt-5.4 | gemini: gemini-3.1-pro | codex: gpt-5.3-codex | openrouter: openrouter/auto | minimax: MiniMax-M2.5
+# anthropic: claude-sonnet-4-6 | openai: gpt-5.4 | gemini: gemini-3.1-pro | codex: gpt-5.3-codex | openrouter: openrouter/auto | minimax: MiniMax-M2.5 | xai: grok-3
 LLM_MODEL=
 
 # === Telegram Alerts (optional, requires LLM) ===

--- a/README.md
+++ b/README.md
@@ -186,10 +186,10 @@ Alerts are delivered as rich embeds with color-coded sidebars: red for FLASH, ye
 **Optional dependency:** The full bot requires `discord.js`. Install it with `npm install discord.js`. If it's not installed, Crucix automatically falls back to webhook-only mode.
 
 ### Optional LLM Layer
-Connect any of 6 LLM providers for enhanced analysis:
+Connect any of 7 LLM providers for enhanced analysis:
 - **AI trade ideas** — quantitative analyst producing 5-8 actionable ideas citing specific data
 - **Smarter alert evaluation** — LLM classifies signals into FLASH/PRIORITY/ROUTINE tiers with cross-domain correlation and confidence scoring
-- Providers: Anthropic Claude, OpenAI, Google Gemini, OpenRouter (Unified API), OpenAI Codex (ChatGPT subscription), MiniMax, Mistral
+- Providers: Anthropic Claude, OpenAI, Google Gemini, OpenRouter (Unified API), OpenAI Codex (ChatGPT subscription), MiniMax, Mistral, xAI Grok
 - Graceful fallback — when LLM is unavailable, a rule-based engine takes over alert evaluation. LLM failures never crash the sweep cycle.
 
 ---
@@ -222,7 +222,7 @@ These three unlock the most valuable economic and satellite data. Each takes abo
 
 ### LLM Provider (optional, for AI-enhanced ideas)
 
-Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`
+Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, `xai`
 
 | Provider | Key Required | Default Model |
 |----------|-------------|---------------|
@@ -233,6 +233,7 @@ Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `openrou
 | `codex` | None (uses `~/.codex/auth.json`) | gpt-5.3-codex |
 | `minimax` | `LLM_API_KEY` | MiniMax-M2.5 |
 | `mistral` | `LLM_API_KEY` | mistral-large-latest |
+| `xai` | `LLM_API_KEY` | grok-3 |
 
 For Codex, run `npx @openai/codex login` to authenticate via your ChatGPT subscription.
 
@@ -302,7 +303,7 @@ crucix/
 │       └── jarvis.html        # Self-contained Jarvis HUD
 │
 ├── lib/
-│   ├── llm/                   # LLM abstraction (5 providers, raw fetch, no SDKs)
+│   ├── llm/                   # LLM abstraction (8 providers, raw fetch, no SDKs)
 │   │   ├── provider.mjs       # Base class
 │   │   ├── anthropic.mjs      # Claude
 │   │   ├── openai.mjs         # GPT
@@ -311,6 +312,7 @@ crucix/
 │   │   ├── codex.mjs          # Codex (ChatGPT subscription)
 │   │   ├── minimax.mjs        # MiniMax (M2.5, 204K context)
 │   │   ├── mistral.mjs        # Mistral AI
+│   │   ├── xai.mjs            # xAI Grok
 │   │   ├── ideas.mjs          # LLM-powered trade idea generation
 │   │   └── index.mjs          # Factory: createLLMProvider()
 │   ├── delta/                 # Change tracking between sweeps
@@ -412,7 +414,7 @@ All settings are in `.env` with sensible defaults:
 |----------|---------|-------------|
 | `PORT` | `3117` | Dashboard server port |
 | `REFRESH_INTERVAL_MINUTES` | `15` | Auto-refresh interval |
-| `LLM_PROVIDER` | disabled | `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, or `mistral` |
+| `LLM_PROVIDER` | disabled | `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, or `xai` |
 | `LLM_API_KEY` | — | API key (not needed for codex) |
 | `LLM_MODEL` | per-provider default | Override model selection |
 | `TELEGRAM_BOT_TOKEN` | disabled | For Telegram alerts + bot commands |

--- a/lib/llm/index.mjs
+++ b/lib/llm/index.mjs
@@ -7,6 +7,7 @@ import { GeminiProvider } from './gemini.mjs';
 import { CodexProvider } from './codex.mjs';
 import { MiniMaxProvider } from './minimax.mjs';
 import { MistralProvider } from './mistral.mjs';
+import { XAIProvider } from './xai.mjs';
 
 export { LLMProvider } from './provider.mjs';
 export { AnthropicProvider } from './anthropic.mjs';
@@ -16,6 +17,7 @@ export { GeminiProvider } from './gemini.mjs';
 export { CodexProvider } from './codex.mjs';
 export { MiniMaxProvider } from './minimax.mjs';
 export { MistralProvider } from './mistral.mjs';
+export { XAIProvider } from './xai.mjs';
 
 /**
  * Create an LLM provider based on config.
@@ -42,6 +44,9 @@ export function createLLMProvider(llmConfig) {
       return new MiniMaxProvider({ apiKey, model });
     case 'mistral':
       return new MistralProvider({ apiKey, model });
+    case 'xai':
+    case 'grok':
+      return new XAIProvider({ apiKey, model });
     default:
       console.warn(`[LLM] Unknown provider "${provider}". LLM features disabled.`);
       return null;

--- a/lib/llm/xai.mjs
+++ b/lib/llm/xai.mjs
@@ -1,0 +1,52 @@
+// xAI Grok Provider — raw fetch, no SDK
+// Uses xAI's OpenAI-compatible Chat Completions API
+// Docs: https://docs.x.ai/docs/guides/reasoning
+
+import { LLMProvider } from './provider.mjs';
+
+export class XAIProvider extends LLMProvider {
+  constructor(config) {
+    super(config);
+    this.name = 'xai';
+    this.apiKey = config.apiKey;
+    this.model = config.model || 'grok-3';
+  }
+
+  get isConfigured() { return !!this.apiKey; }
+
+  async complete(systemPrompt, userMessage, opts = {}) {
+    const res = await fetch('https://api.x.ai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.model,
+        max_tokens: opts.maxTokens || 4096,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userMessage },
+        ],
+      }),
+      signal: AbortSignal.timeout(opts.timeout || 60000),
+    });
+
+    if (!res.ok) {
+      const err = await res.text().catch(() => '');
+      throw new Error(`xAI API ${res.status}: ${err.substring(0, 200)}`);
+    }
+
+    const data = await res.json();
+    const text = data.choices?.[0]?.message?.content || '';
+
+    return {
+      text,
+      usage: {
+        inputTokens: data.usage?.prompt_tokens || 0,
+        outputTokens: data.usage?.completion_tokens || 0,
+      },
+      model: data.model || this.model,
+    };
+  }
+}

--- a/test/llm-xai.test.mjs
+++ b/test/llm-xai.test.mjs
@@ -1,0 +1,145 @@
+// xAI Grok provider — unit tests
+// Uses Node.js built-in test runner (node:test) — no extra dependencies
+
+import { describe, it, mock, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { XAIProvider } from '../lib/llm/xai.mjs';
+import { createLLMProvider } from '../lib/llm/index.mjs';
+
+// ─── Unit Tests ───
+
+describe('XAIProvider', () => {
+  it('should set defaults correctly', () => {
+    const provider = new XAIProvider({ apiKey: 'xai-test' });
+    assert.equal(provider.name, 'xai');
+    assert.equal(provider.model, 'grok-3');
+    assert.equal(provider.isConfigured, true);
+  });
+
+  it('should accept custom model', () => {
+    const provider = new XAIProvider({ apiKey: 'xai-test', model: 'grok-3-mini' });
+    assert.equal(provider.model, 'grok-3-mini');
+  });
+
+  it('should report not configured without API key', () => {
+    const provider = new XAIProvider({});
+    assert.equal(provider.isConfigured, false);
+  });
+
+  it('should throw on API error', async () => {
+    const provider = new XAIProvider({ apiKey: 'xai-test' });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(() =>
+      Promise.resolve({ ok: false, status: 401, text: () => Promise.resolve('Unauthorized') })
+    );
+    try {
+      await assert.rejects(
+        () => provider.complete('system', 'user'),
+        (err) => {
+          assert.match(err.message, /xAI API 401/);
+          return true;
+        }
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should parse successful response', async () => {
+    const provider = new XAIProvider({ apiKey: 'xai-test' });
+    const mockResponse = {
+      choices: [{ message: { content: 'Hello from Grok' } }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+      model: 'grok-3',
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+    );
+    try {
+      const result = await provider.complete('You are helpful.', 'Say hello');
+      assert.equal(result.text, 'Hello from Grok');
+      assert.equal(result.usage.inputTokens, 10);
+      assert.equal(result.usage.outputTokens, 5);
+      assert.equal(result.model, 'grok-3');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should send correct request format', async () => {
+    const provider = new XAIProvider({ apiKey: 'xai-key-123', model: 'grok-3' });
+    let capturedUrl, capturedOpts;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn((url, opts) => {
+      capturedUrl = url;
+      capturedOpts = opts;
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'ok' } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+          model: 'grok-3',
+        }),
+      });
+    });
+    try {
+      await provider.complete('system prompt', 'user message', { maxTokens: 2048 });
+      assert.equal(capturedUrl, 'https://api.x.ai/v1/chat/completions');
+      assert.equal(capturedOpts.method, 'POST');
+      const headers = capturedOpts.headers;
+      assert.equal(headers['Content-Type'], 'application/json');
+      assert.equal(headers['Authorization'], 'Bearer xai-key-123');
+      const body = JSON.parse(capturedOpts.body);
+      assert.equal(body.model, 'grok-3');
+      assert.equal(body.max_tokens, 2048);
+      assert.equal(body.messages[0].role, 'system');
+      assert.equal(body.messages[0].content, 'system prompt');
+      assert.equal(body.messages[1].role, 'user');
+      assert.equal(body.messages[1].content, 'user message');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should handle empty response gracefully', async () => {
+    const provider = new XAIProvider({ apiKey: 'xai-test' });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ choices: [], usage: {} }),
+      })
+    );
+    try {
+      const result = await provider.complete('sys', 'user');
+      assert.equal(result.text, '');
+      assert.equal(result.usage.inputTokens, 0);
+      assert.equal(result.usage.outputTokens, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ─── Factory Tests ───
+
+describe('createLLMProvider — xai', () => {
+  it('should create XAIProvider for provider=xai', () => {
+    const provider = createLLMProvider({ provider: 'xai', apiKey: 'xai-test', model: null });
+    assert.ok(provider instanceof XAIProvider);
+    assert.equal(provider.name, 'xai');
+    assert.equal(provider.isConfigured, true);
+  });
+
+  it('should create XAIProvider for provider=grok alias', () => {
+    const provider = createLLMProvider({ provider: 'grok', apiKey: 'xai-test', model: null });
+    assert.ok(provider instanceof XAIProvider);
+    assert.equal(provider.name, 'xai');
+  });
+
+  it('should be case-insensitive', () => {
+    const provider = createLLMProvider({ provider: 'XAI', apiKey: 'xai-test', model: null });
+    assert.ok(provider instanceof XAIProvider);
+  });
+});


### PR DESCRIPTION
## Summary

Adds xAI Grok as the 8th LLM provider in Crucix.

- New `lib/llm/xai.mjs` provider using xAI's OpenAI-compatible Chat Completions API (`https://api.x.ai/v1`)
- Both `xai` and `grok` accepted as provider name (case-insensitive)
- Default model: `grok-3`
- Full unit test suite (`test/llm-xai.test.mjs`) — 10 tests, all passing
- Updated `.env.example`, `README.md` (provider table, architecture tree, env reference)

## Usage

```env
LLM_PROVIDER=xai
LLM_API_KEY=xai-your-key
LLM_MODEL=grok-3        # optional, this is the default
```

## Test plan

- [x] `node --test test/llm-xai.test.mjs` — 10/10 pass
- [x] Factory creates `XAIProvider` for both `xai` and `grok` aliases
- [x] Correct API endpoint, headers, and request body format
- [x] Error handling and empty response edge cases
- [ ] Integration test with live xAI API key (not included, requires key)

Closes #54