### PR TITLE
fix: resolve horizontal overflow on mobile control panel

### DIFF
--- a/dashboard/public/jarvis.html
+++ b/dashboard/public/jarvis.html
@@ -277,7 +277,7 @@ body.low-perf .ticker-wrap::-webkit-scrollbar-thumb{background:rgba(100,240,200,
   .top-left,.top-center,.top-right{width:100%}
   .top-center{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:6px}
   .map-region-bar{display:none}
-  .top-right{gap:6px}
+  .top-right{gap:6px ; flex-wrap: wrap; justify-content: center;}
   .region-btn,.meta-pill,.alert-badge,.guide-btn{font-size:10px}
   .grid{display:flex;flex-direction:column}
   #centerCol{order:1}


### PR DESCRIPTION
## Summary
Closes #64.
This PR fixes the horizontal overflow issue on mobile viewports for the top control panel. Added `flex-wrap: wrap` and `justify-content: center` to the `.top-right` container inside the mobile media query.

## Why
On smaller screens, the control panel was strictly horizontal, pushing the rightmost buttons ("Sources", "What Signals Mean", etc.) off-screen and making them completely inaccessible to mobile users.

## Scope
- [x] Focused bug fix
- [x] Small UX improvement
- [ ] New source
- [ ] Dashboard change
- [ ] Docs/config change

## Validation
Tested locally using browser DevTools mobile device simulation. Verified that the buttons now stack neatly into grid rows on small screens without breaking the page width.

## Screenshots
![after](https://github.com/user-attachments/assets/3e472e6b-a721-47e2-bb0a-918c330e3865)
![before](https://github.com/user-attachments/assets/c2d5b367-05cb-4f7b-9acc-37ba1fc2c5fa)


## Config and Docs
- [x] No new environment variables
- [ ] `.env.example` updated if needed
- [ ] `README.md` updated if behavior changed

## Source Additions
*N/A - CSS bug fix only.*

## Checklist
- [x] This PR stays within one bugfix or one feature family
- [x] I kept unrelated changes out of the diff
- [x] I considered security for any mixed-source content rendering
- [x] I tested the changed path locally