### PR TITLE
fix: always fetch live API data in server mode

### DIFF
--- a/dashboard/public/jarvis.html
+++ b/dashboard/public/jarvis.html
@@ -1763,7 +1763,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const hasInlineData = !!(D && D.meta);
   const canProbeApi = location.protocol !== 'file:';
 
-  if (canProbeApi && !hasInlineData) {
+  if (canProbeApi) {
     // Server mode: always fetch live data from API (ignore any stale inline D)
     fetch('/api/data')
       .then(r => r.json())


### PR DESCRIPTION
## Problem

When running Crucix in Docker/Kubernetes, the dashboard shows stale data from the Docker image build time instead of live intelligence data.

The `DOMContentLoaded` handler in `jarvis.html` checks:
```js
if (canProbeApi && !hasInlineData) {
```

But the inline data variable `D` is always populated at build time (line 375), so `hasInlineData` is always `true` and the `/api/data` fetch is never executed. The dashboard renders the baked-in snapshot forever.

## Fix

Change the condition to just `canProbeApi`:
```js
if (canProbeApi) {
```

This makes the dashboard always fetch from `/api/data` when running on a server (HTTP/HTTPS). File mode (local HTML file) still uses inline data as fallback since `canProbeApi` is `false` for `file://` protocol.

## Impact

- Docker/K8s deployments now show real-time data instead of build-time snapshot
- No change to file-mode behavior (offline viewing still works)
- The `connectSSE()` call in the fetch handler ensures live updates continue after initial load

🤖 Generated with [Claude Code](https://claude.com/claude-code)