### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,10 @@ Alerts are delivered as rich embeds with color-coded sidebars: red for FLASH, ye
 **Optional dependency:** The full bot requires `discord.js`. Install it with `npm install discord.js`. If it's not installed, Crucix automatically falls back to webhook-only mode.
 
 ### Optional LLM Layer
-Connect any of 8 LLM providers for enhanced analysis:
+Connect any of 9 LLM providers for enhanced analysis:
 - **AI trade ideas** — quantitative analyst producing 5-8 actionable ideas citing specific data
 - **Smarter alert evaluation** — LLM classifies signals into FLASH/PRIORITY/ROUTINE tiers with cross-domain correlation and confidence scoring
-- Providers: Anthropic Claude, OpenAI, Google Gemini, OpenRouter (Unified API), OpenAI Codex (ChatGPT subscription), MiniMax, Mistral, Grok
+- Providers: Anthropic Claude, OpenAI, Google Gemini, OpenRouter (Unified API), OpenAI Codex (ChatGPT subscription), MiniMax, Mistral, Grok, Novita
 - Graceful fallback — when LLM is unavailable, a rule-based engine takes over alert evaluation. LLM failures never crash the sweep cycle.
 
 ---
@@ -222,7 +222,7 @@ These three unlock the most valuable economic and satellite data. Each takes abo
 
 ### LLM Provider (optional, for AI-enhanced ideas)
 
-Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, `grok`
+Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, `grok`, `novita`
 
 | Provider | Key Required | Default Model |
 |----------|-------------|---------------|
@@ -234,6 +234,7 @@ Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `openrou
 | `minimax` | `LLM_API_KEY` | MiniMax-M2.5 |
 | `mistral` | `LLM_API_KEY` | mistral-large-latest |
 | `grok` | `LLM_API_KEY` | grok-4-latest |
+| `novita` | `LLM_API_KEY` | moonshotai/kimi-k2.5 |
 
 For Codex, run `npx @openai/codex login` to authenticate via your ChatGPT subscription.
 
@@ -303,7 +304,7 @@ crucix/
 │       └── jarvis.html        # Self-contained Jarvis HUD
 │
 ├── lib/
-│   ├── llm/                   # LLM abstraction (8 providers, raw fetch, no SDKs)
+│   ├── llm/                   # LLM abstraction (9 providers, raw fetch, no SDKs)
 │   │   ├── provider.mjs       # Base class
 │   │   ├── anthropic.mjs      # Claude
 │   │   ├── openai.mjs         # GPT
@@ -313,6 +314,7 @@ crucix/
 │   │   ├── codex.mjs          # Codex (ChatGPT subscription)
 │   │   ├── minimax.mjs        # MiniMax (M2.5, 204K context)
 │   │   ├── mistral.mjs        # Mistral AI
+│   │   ├── novita.mjs         # Novita AI
 │   │   ├── ideas.mjs          # LLM-powered trade idea generation
 │   │   └── index.mjs          # Factory: createLLMProvider()
 │   ├── delta/                 # Change tracking between sweeps
@@ -414,7 +416,7 @@ All settings are in `.env` with sensible defaults:
 |----------|---------|-------------|
 | `PORT` | `3117` | Dashboard server port |
 | `REFRESH_INTERVAL_MINUTES` | `15` | Auto-refresh interval |
-| `LLM_PROVIDER` | disabled | `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, or `grok` |
+| `LLM_PROVIDER` | disabled | `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, `grok`, or `novita` |
 | `LLM_API_KEY` | — | API key (not needed for codex) |
 | `LLM_MODEL` | per-provider default | Override model selection |
 | `TELEGRAM_BOT_TOKEN` | disabled | For Telegram alerts + bot commands |

--- a/crucix.config.mjs
+++ b/crucix.config.mjs
@@ -7,7 +7,7 @@ export default {
   refreshIntervalMinutes: parseInt(process.env.REFRESH_INTERVAL_MINUTES) || 15,
 
   llm: {
-    provider: process.env.LLM_PROVIDER || null, // anthropic | openai | gemini | codex | openrouter | minimax | mistral | ollama | grok
+    provider: process.env.LLM_PROVIDER || null, // anthropic | openai | gemini | codex | openrouter | minimax | mistral | ollama | grok | novita
     apiKey: process.env.LLM_API_KEY || null,
     model: process.env.LLM_MODEL || null,
     baseUrl: process.env.OLLAMA_BASE_URL || null,

--- a/lib/llm/index.mjs
+++ b/lib/llm/index.mjs
@@ -9,6 +9,7 @@ import { MiniMaxProvider } from "./minimax.mjs";
 import { MistralProvider } from "./mistral.mjs";
 import { OllamaProvider } from "./ollama.mjs";
 import { GrokProvider } from "./grok.mjs";
+import { NovitaProvider } from "./novita.mjs";
 
 export { LLMProvider } from "./provider.mjs";
 export { AnthropicProvider } from "./anthropic.mjs";
@@ -20,6 +21,7 @@ export { MiniMaxProvider } from "./minimax.mjs";
 export { MistralProvider } from "./mistral.mjs";
 export { OllamaProvider } from "./ollama.mjs";
 export { GrokProvider } from "./grok.mjs";
+export { NovitaProvider } from "./novita.mjs";
 
 /**
  * Create an LLM provider based on config.
@@ -50,6 +52,8 @@ export function createLLMProvider(llmConfig) {
       return new OllamaProvider({ model, baseUrl: llmConfig.baseUrl });
     case 'grok':
       return new GrokProvider({ apiKey, model });
+    case 'novita':
+      return new NovitaProvider({ apiKey, model });
     default:
       console.warn(
         `[LLM] Unknown provider "${provider}". LLM features disabled.`,

--- a/lib/llm/novita.mjs
+++ b/lib/llm/novita.mjs
@@ -1,0 +1,51 @@
+// Novita Provider — raw fetch, no SDK
+// Uses Novita's OpenAI-compatible Chat Completions API
+
+import { LLMProvider } from './provider.mjs';
+
+export class NovitaProvider extends LLMProvider {
+  constructor(config) {
+    super(config);
+    this.name = 'novita';
+    this.apiKey = config.apiKey;
+    this.model = config.model || 'moonshotai/kimi-k2.5';
+  }
+
+  get isConfigured() { return !!this.apiKey; }
+
+  async complete(systemPrompt, userMessage, opts = {}) {
+    const res = await fetch('https://api.novita.ai/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.model,
+        max_tokens: opts.maxTokens || 4096,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userMessage },
+        ],
+      }),
+      signal: AbortSignal.timeout(opts.timeout || 60000),
+    });
+
+    if (!res.ok) {
+      const err = await res.text().catch(() => '');
+      throw new Error(`Novita API ${res.status}: ${err.substring(0, 200)}`);
+    }
+
+    const data = await res.json();
+    const text = data.choices?.[0]?.message?.content || '';
+
+    return {
+      text,
+      usage: {
+        inputTokens: data.usage?.prompt_tokens || 0,
+        outputTokens: data.usage?.completion_tokens || 0,
+      },
+      model: data.model || this.model,
+    };
+  }
+}

--- a/test/llm-novita.test.mjs
+++ b/test/llm-novita.test.mjs
@@ -1,0 +1,141 @@
+// Novita provider — unit tests
+// Uses Node.js built-in test runner (node:test) — no extra dependencies
+
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { NovitaProvider } from '../lib/llm/novita.mjs';
+import { createLLMProvider } from '../lib/llm/index.mjs';
+
+describe('NovitaProvider', () => {
+  it('should set defaults correctly', () => {
+    const provider = new NovitaProvider({ apiKey: 'sk-test' });
+    assert.equal(provider.name, 'novita');
+    assert.equal(provider.model, 'moonshotai/kimi-k2.5');
+    assert.equal(provider.isConfigured, true);
+  });
+
+  it('should accept custom model', () => {
+    const provider = new NovitaProvider({ apiKey: 'sk-test', model: 'deepseek/deepseek-v3.1' });
+    assert.equal(provider.model, 'deepseek/deepseek-v3.1');
+  });
+
+  it('should report not configured without API key', () => {
+    const provider = new NovitaProvider({});
+    assert.equal(provider.isConfigured, false);
+  });
+
+  it('should throw on API error', async () => {
+    const provider = new NovitaProvider({ apiKey: 'sk-test' });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(() =>
+      Promise.resolve({ ok: false, status: 401, text: () => Promise.resolve('Unauthorized') })
+    );
+    try {
+      await assert.rejects(
+        () => provider.complete('system', 'user'),
+        (err) => {
+          assert.match(err.message, /Novita API 401/);
+          return true;
+        }
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should parse successful response', async () => {
+    const provider = new NovitaProvider({ apiKey: 'sk-test' });
+    const mockResponse = {
+      choices: [{ message: { content: 'Hello from Novita' } }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+      model: 'moonshotai/kimi-k2.5',
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+    );
+    try {
+      const result = await provider.complete('You are helpful.', 'Say hello');
+      assert.equal(result.text, 'Hello from Novita');
+      assert.equal(result.usage.inputTokens, 10);
+      assert.equal(result.usage.outputTokens, 5);
+      assert.equal(result.model, 'moonshotai/kimi-k2.5');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should send correct request format', async () => {
+    const provider = new NovitaProvider({ apiKey: 'sk-test-key', model: 'moonshotai/kimi-k2.5' });
+    let capturedUrl;
+    let capturedOpts;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn((url, opts) => {
+      capturedUrl = url;
+      capturedOpts = opts;
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'ok' } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+          model: 'moonshotai/kimi-k2.5',
+        }),
+      });
+    });
+    try {
+      await provider.complete('system prompt', 'user message', { maxTokens: 2048 });
+      assert.equal(capturedUrl, 'https://api.novita.ai/openai/v1/chat/completions');
+      assert.equal(capturedOpts.method, 'POST');
+      const headers = capturedOpts.headers;
+      assert.equal(headers['Content-Type'], 'application/json');
+      assert.equal(headers['Authorization'], 'Bearer sk-test-key');
+      const body = JSON.parse(capturedOpts.body);
+      assert.equal(body.model, 'moonshotai/kimi-k2.5');
+      assert.equal(body.max_tokens, 2048);
+      assert.equal(body.messages[0].role, 'system');
+      assert.equal(body.messages[0].content, 'system prompt');
+      assert.equal(body.messages[1].role, 'user');
+      assert.equal(body.messages[1].content, 'user message');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should handle empty response gracefully', async () => {
+    const provider = new NovitaProvider({ apiKey: 'sk-test' });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ choices: [], usage: {} }),
+      })
+    );
+    try {
+      const result = await provider.complete('sys', 'user');
+      assert.equal(result.text, '');
+      assert.equal(result.usage.inputTokens, 0);
+      assert.equal(result.usage.outputTokens, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe('createLLMProvider — novita', () => {
+  it('should create NovitaProvider for provider=novita', () => {
+    const provider = createLLMProvider({ provider: 'novita', apiKey: 'sk-test', model: null });
+    assert.ok(provider instanceof NovitaProvider);
+    assert.equal(provider.name, 'novita');
+    assert.equal(provider.isConfigured, true);
+  });
+
+  it('should be case-insensitive', () => {
+    const provider = createLLMProvider({ provider: 'Novita', apiKey: 'sk-test', model: null });
+    assert.ok(provider instanceof NovitaProvider);
+  });
+
+  it('should return null for empty provider', () => {
+    const provider = createLLMProvider({ provider: null, apiKey: 'sk-test', model: null });
+    assert.equal(provider, null);
+  });
+});


### PR DESCRIPTION
## Summary

Add [Novita AI](https://novita.ai) as a new LLM provider option in Crucix.

### Changes
- add a raw-fetch Novita provider using Novita's OpenAI-compatible chat completions endpoint
- register `novita` in the LLM provider factory and config surface
- document the new provider and its default model in the README
- add focused unit tests for provider creation and request/response behavior

### Configuration
```bash
LLM_PROVIDER=novita
LLM_API_KEY=your_novita_key
LLM_MODEL=moonshotai/kimi-k2.5
```

**Endpoint**: `https://api.novita.ai/openai`

### Validation
- `node --test test/llm-novita.test.mjs`
