### PR TITLE
fix(env): strip surrounding quotes from .env values

### DIFF
--- a/apis/utils/env.mjs
+++ b/apis/utils/env.mjs
@@ -20,7 +20,11 @@ function loadEnv(filePath) {
       const eq = trimmed.indexOf('=');
       if (eq === -1) continue;
       const key = trimmed.slice(0, eq).trim();
-      const val = trimmed.slice(eq + 1).trim();
+      let val = trimmed.slice(eq + 1).trim();
+      // Strip surrounding quotes (single or double) to support special characters
+      if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+        val = val.slice(1, -1);
+      }
       if (!process.env[key]) { process.env[key] = val; loaded++; }
     }
     return loaded;


### PR DESCRIPTION
## Problem

The custom `.env` parser in `apis/utils/env.mjs` does not handle quoted values. Passwords and API keys containing special characters (`|`, `^`, `"`, `>`, `[`, `#`, etc.) either parse incorrectly or include the quote characters as part of the value.

For example, an ACLED password like:
```
ACLED_PASSWORD='Fvb|=K^j6"}ceIOtv^45>w/[3'
```
would be parsed as `'Fvb|=K^j6"}ceIOtv^45>w/[3'` (with the surrounding quotes included), causing authentication failures.

## Fix

Strip matching surrounding quotes (single or double) from values after trimming, consistent with how `dotenv` and other standard `.env` parsers behave.

## Changes

- `apis/utils/env.mjs`: Added quote-stripping logic (4 lines)

## Testing

Verified that:
- Unquoted values continue to work as before
- Single-quoted values with special characters parse correctly
- Double-quoted values parse correctly
- Values with mismatched or internal quotes are left untouched