### PR TITLE
fix(llm): Gemini 2.5 compatibility — thinking parts and response parsing

### DIFF
--- a/apis/utils/env.mjs
+++ b/apis/utils/env.mjs
@@ -20,7 +20,11 @@ function loadEnv(filePath) {
       const eq = trimmed.indexOf('=');
       if (eq === -1) continue;
       const key = trimmed.slice(0, eq).trim();
-      const val = trimmed.slice(eq + 1).trim();
+      let val = trimmed.slice(eq + 1).trim();
+      // Strip surrounding quotes (single or double) to support special characters
+      if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+        val = val.slice(1, -1);
+      }
       if (!process.env[key]) { process.env[key] = val; loaded++; }
     }
     return loaded;

--- a/crucix.config.mjs
+++ b/crucix.config.mjs
@@ -4,6 +4,7 @@ import "./apis/utils/env.mjs"; // Load .env first
 
 export default {
   port: parseInt(process.env.PORT) || 3117,
+  publicUrl: process.env.PUBLIC_URL || null,
   refreshIntervalMinutes: parseInt(process.env.REFRESH_INTERVAL_MINUTES) || 15,
 
   llm: {

--- a/lib/alerts/discord.mjs
+++ b/lib/alerts/discord.mjs
@@ -59,22 +59,22 @@ export class DiscordAlerter {
         intents: [GatewayIntentBits.Guilds],
       });
 
-      // Register slash commands
-      await this._registerCommands(REST, Routes, SlashCommandBuilder);
-
       // Handle slash command interactions
       this._client.on('interactionCreate', async (interaction) => {
         if (!interaction.isChatInputCommand()) return;
         await this._handleCommand(interaction);
       });
 
-      // Connect
-      await this._client.login(this.botToken);
-
-      this._client.once('ready', () => {
+      // Register ready handler before login so we don't miss the event
+      this._client.once('ready', async () => {
         this._ready = true;
         console.log(`[Discord] Bot online as ${this._client.user.tag}`);
+        // Register slash commands after login so client.user.id is available
+        await this._registerCommands(REST, Routes, SlashCommandBuilder);
       });
+
+      // Connect
+      await this._client.login(this.botToken);
 
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND' || err.message?.includes('Cannot find')) {

--- a/lib/llm/gemini.mjs
+++ b/lib/llm/gemini.mjs
@@ -23,6 +23,9 @@ export class GeminiProvider extends LLMProvider {
         contents: [{ parts: [{ text: userMessage }] }],
         generationConfig: {
           maxOutputTokens: opts.maxTokens || 4096,
+          // Gemini 2.5 models use thinking tokens from a separate budget;
+          // set thinkingConfig to keep reasoning concise
+          thinkingConfig: { thinkingBudget: 1024 },
         },
       }),
       signal: AbortSignal.timeout(opts.timeout || 60000),
@@ -34,7 +37,14 @@ export class GeminiProvider extends LLMProvider {
     }
 
     const data = await res.json();
-    const text = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+    // Gemini 2.5+ models may return multiple parts (thinking + response)
+    // Filter out thinking parts and concatenate the rest
+    const parts = data.candidates?.[0]?.content?.parts || [];
+    const text = parts
+      .filter(p => !p.thought)  // Skip thinking/reasoning parts
+      .map(p => p.text || '')
+      .join('\n')
+      .trim() || '';
 
     return {
       text,

--- a/lib/llm/ideas.mjs
+++ b/lib/llm/ideas.mjs
@@ -43,12 +43,12 @@ Output ONLY valid JSON array. Each object:
 }`;
 
   try {
-    const result = await provider.complete(systemPrompt, context, { maxTokens: 4096, timeout: 90000 });
+    const result = await provider.complete(systemPrompt, context, { maxTokens: 8192, timeout: 90000 });
     const ideas = parseIdeasResponse(result.text);
     if (ideas && ideas.length > 0) {
       return ideas;
     }
-    console.warn('[LLM Ideas] No valid ideas parsed from response');
+    console.warn('[LLM Ideas] No valid ideas parsed from response. Raw length:', result.text?.length, 'First 1000 chars:', JSON.stringify(result.text?.slice(0, 1000)));
     return null;
   } catch (err) {
     console.error('[LLM Ideas] Generation failed:', err.message);
@@ -167,10 +167,19 @@ function compactSweepForLLM(data, delta, previousIdeas) {
 function parseIdeasResponse(text) {
   if (!text) return null;
 
-  // Strip markdown code block wrappers
+  // Strip markdown code block wrappers (handles trailing whitespace, thinking tags, etc.)
   let cleaned = text.trim();
-  if (cleaned.startsWith('```')) {
-    cleaned = cleaned.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+  // Extract content from code blocks anywhere in the response
+  const codeBlockMatch = cleaned.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+  if (codeBlockMatch) {
+    cleaned = codeBlockMatch[1].trim();
+  } else if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\n?/, '').replace(/\n?```\s*$/, '');
+  }
+  // Strip any leading/trailing non-JSON text (find the array)
+  const arrayMatch = cleaned.match(/(\[[\s\S]*\])/);
+  if (arrayMatch) {
+    cleaned = arrayMatch[1];
   }
 
   try {

--- a/server.mjs
+++ b/server.mjs
@@ -71,7 +71,7 @@ if (telegramAlerter.isConfigured) {
       `Sources: ${sourcesOk}/${sourcesTotal} OK${sourcesFailed > 0 ? ` (${sourcesFailed} failed)` : ''}`,
       `LLM: ${llmStatus}`,
       `SSE clients: ${sseClients.size}`,
-      `Dashboard: http://localhost:${config.port}`,
+      `Dashboard: ${config.publicUrl || `http://localhost:${config.port}`}`,
     ].join('\n');
   });
 
@@ -169,7 +169,7 @@ if (discordAlerter.isConfigured) {
       `Sources: ${sourcesOk}/${sourcesTotal} OK${sourcesFailed > 0 ? ` (${sourcesFailed} failed)` : ''}`,
       `LLM: ${llmStatus}`,
       `SSE clients: ${sseClients.size}`,
-      `Dashboard: http://localhost:${config.port}`,
+      `Dashboard: ${config.publicUrl || `http://localhost:${config.port}`}`,
     ].join('\n');
   });
 


### PR DESCRIPTION
## Problem

Gemini 2.5 Flash and Pro models fail to generate trade ideas due to three compounding issues:

### 1. Thinking parts in multi-part responses
Gemini 2.5 models return `parts` arrays where the first element is a \thinking\ part (`thought: true`) and the actual response is in subsequent parts. The provider reads only `parts[0]`, so it gets raw reasoning instead of the JSON output.

### 2. Truncated output from thinking token budget
Thinking tokens consume the `maxOutputTokens` budget, leaving insufficient tokens for the actual response. This causes the JSON array to be cut mid-object (e.g., 693 chars instead of ~2000+), making it unparseable.

### 3. Brittle code block extraction
The ideas parser only handled code blocks at exact string boundaries (`startsWith` / regex anchored to `$`). Gemini responses may have trailing whitespace, extra text, or different formatting that breaks extraction.

**Result:** `[LLM Ideas] No valid ideas parsed from response` on every sweep with Gemini 2.5 Flash/Pro, despite the model returning valid ideas inside the response.

## Fix

### `lib/llm/gemini.mjs`
- Filter out `thought` parts from response, concatenate only non-thinking parts
- Add `thinkingConfig: { thinkingBudget: 1024 }` to keep reasoning concise and preserve output token budget

### `lib/llm/ideas.mjs`
- Rewrite code block extraction to find `\`\`\`json...\`\`\`` blocks anywhere in the response (not just at boundaries)
- Add fallback: extract the JSON array (`[...]`) directly if no code block is found
- Bump `maxTokens` from 4096 to 8192 for idea generation

## Testing

Before: `0 ideas (llm-failed)` on every sweep with `gemini-2.5-flash`
After: `5 ideas (llm)` consistently generated and parsed correctly