### PR TITLE
feat(i18n): add Chinese locale + real-time LLM translation

### DIFF
--- a/lib/i18n.mjs
+++ b/lib/i18n.mjs
@@ -10,7 +10,7 @@ const __dirname = dirname(__filename);
 const LOCALES_DIR = join(__dirname, '..', 'locales');
 
 // Supported languages
-const SUPPORTED_LOCALES = ['en', 'fr'];
+const SUPPORTED_LOCALES = ['en', 'fr', 'zh'];
 const DEFAULT_LOCALE = 'en';
 
 // Cache loaded locales

--- a/lib/llm/index.mjs
+++ b/lib/llm/index.mjs
@@ -43,7 +43,7 @@ export function createLLMProvider(llmConfig) {
     case "codex":
       return new CodexProvider({ model });
     case "minimax":
-      return new MiniMaxProvider({ apiKey, model });
+      return new MiniMaxProvider({ apiKey, model, apiBase: llmConfig.apiBase });
     case "mistral":
       return new MistralProvider({ apiKey, model });
     case "ollama":

--- a/lib/llm/minimax.mjs
+++ b/lib/llm/minimax.mjs
@@ -1,5 +1,6 @@
 // MiniMax Provider — raw fetch, no SDK
 // Uses MiniMax's OpenAI-compatible Chat Completions API
+// Endpoint: api.minimaxi.com (not api.minimax.io)
 
 import { LLMProvider } from './provider.mjs';
 
@@ -8,13 +9,14 @@ export class MiniMaxProvider extends LLMProvider {
     super(config);
     this.name = 'minimax';
     this.apiKey = config.apiKey;
-    this.model = config.model || 'MiniMax-M2.5';
+    this.model = config.model || 'MiniMax-M2.7';
+    this.apiBase = config.apiBase || 'https://api.minimaxi.com/v1';
   }
 
   get isConfigured() { return !!this.apiKey; }
 
   async complete(systemPrompt, userMessage, opts = {}) {
-    const res = await fetch('https://api.minimax.io/v1/chat/completions', {
+    const res = await fetch(`${this.apiBase}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -23,6 +25,7 @@ export class MiniMaxProvider extends LLMProvider {
       body: JSON.stringify({
         model: this.model,
         max_tokens: opts.maxTokens || 4096,
+        temperature: opts.temperature ?? 0.7,
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userMessage },

--- a/lib/translation/index.mjs
+++ b/lib/translation/index.mjs
@@ -1,0 +1,296 @@
+// Translation Service for Crucix
+// Provides real-time bilingual translation using MiniMax-M2.7
+// Designed to work alongside the i18n static labels system
+
+import { createRequire } from 'node:url';
+const require = createRequire(import.meta.url);
+try { require('../../.env'); } catch {} // Load LLM_API_KEY
+
+import { createLLMProvider } from '../llm/index.mjs';
+import { config } from '../../crucix.config.mjs';
+
+// LLM provider (lazy init)
+let _provider = null;
+function getLLMProvider() {
+  if (!_provider) {
+    _provider = createLLMProvider(config.llm);
+  }
+  return _provider;
+}
+
+// LRU translation cache (key = text|context)
+const _cache = new Map();
+const MAX_CACHE = 2000;
+
+// Bilingual metric/indicator names (static, no LLM call needed)
+const METRIC_LABELS = {
+  // FRED indicators
+  'VIXCLS':         { en: 'VIXCLS', zh: 'VIX 恐慌指数', abbr: 'VIX' },
+  'BAMLH0A0HYM2':    { en: 'BAMLH0A0HYM2', zh: '高收益债利差', abbr: 'HY利差' },
+  'T10Y2Y':          { en: 'T10Y2Y', zh: '10Y-2Y收益率差', abbr: '10Y-2Y' },
+  'T10Y3M':          { en: 'T10Y3M', zh: '10Y-3M收益率差', abbr: '10Y-3M' },
+  'DFF':             { en: 'DFF', zh: '联邦基金利率', abbr: 'FF Rate' },
+  'DGS10':           { en: 'DGS10', zh: '10年期国债收益率', abbr: '10Y Yield' },
+  'DGS2':            { en: 'DGS2', zh: '2年期国债收益率', abbr: '2Y Yield' },
+  'DGS30':           { en: 'DGS30', zh: '30年期国债收益率', abbr: '30Y Yield' },
+  'CPIAUCSL':        { en: 'CPIAUCSL', zh: 'CPI 消费者价格指数', abbr: 'CPI' },
+  'CPILFESL':        { en: 'CPILFESL', zh: '核心CPI (排除食品能源)', abbr: 'Core CPI' },
+  'PCEPI':           { en: 'PCEPI', zh: 'PCE个人消费支出价格指数', abbr: 'PCE' },
+  'MICH':            { en: 'MICH', zh: '密歇根通胀预期', abbr: 'Inflation Exp.' },
+  'UNRATE':          { en: 'UNRATE', zh: '失业率', abbr: 'Unemp.' },
+  'PAYEMS':          { en: 'PAYEMS', zh: '非农就业人数', abbr: 'Payrolls' },
+  'ICSA':            { en: 'ICSA', zh: '初请失业金人数', abbr: 'Claims' },
+  'M2SL':            { en: 'M2SL', zh: 'M2 货币供应量', abbr: 'M2' },
+  'WALCL':           { en: 'WALCL', zh: '美联储总资产', abbr: 'Fed Assets' },
+  'DCOILWTICO':      { en: 'DCOILWTICO', zh: 'WTI 原油价格', abbr: 'WTI' },
+  'GOLDAMGBD228NLBM':{ en: 'GOLDAMGBD228NLBM', zh: '伦敦金价', abbr: 'Gold' },
+  'MORTGAGE30US':    { en: 'MORTGAGE30US', zh: '30年期抵押贷款利率', abbr: '30Y Mort.' },
+  'DTWEXBGS':        { en: 'DTWEXBGS', zh: '美元贸易加权指数', abbr: 'USD Index' },
+  // Commodities
+  'wti':             { en: 'WTI', zh: 'WTI 原油', abbr: 'WTI' },
+  'brent':           { en: 'Brent', zh: '布伦特原油', abbr: 'Brent' },
+  'natgas':          { en: 'Nat. Gas', zh: '天然气', abbr: 'Nat. Gas' },
+  'gold':            { en: 'Gold', zh: '黄金', abbr: 'Gold' },
+  'silver':          { en: 'Silver', zh: '白银', abbr: 'Silver' },
+  // Source labels
+  'GDELT':           { en: 'GDELT', zh: 'GDELT 全球新闻数据库', abbr: 'GDELT' },
+  'FIRMS':           { en: 'FIRMS', zh: 'FIRMS 火点监测', abbr: 'FIRMS' },
+  'OpenSky':         { en: 'OpenSky', zh: 'OpenSky 航班追踪', abbr: 'OpenSky' },
+  'ACLED':           { en: 'ACLED', zh: 'ACLED 冲突数据', abbr: 'ACLED' },
+  'NOAA':            { en: 'NOAA', zh: 'NOAA 气象预警', abbr: 'NOAA' },
+  'WHO':             { en: 'WHO', zh: '世卫组织', abbr: 'WHO' },
+  'EIA':             { en: 'EIA', zh: '能源信息署', abbr: 'EIA' },
+  'FRED':            { en: 'FRED', zh: '美联储经济数据', abbr: 'FRED' },
+  'BLS':             { en: 'BLS', zh: '劳工统计局', abbr: 'BLS' },
+  'USAspending':     { en: 'USAspending', zh: '美国政府支出', abbr: 'USAspend' },
+  // Market terms
+  'bull_market':     { en: 'Bull Market', zh: '牛市', abbr: '牛市' },
+  'bear_market':     { en: 'Bear Market', zh: '熊市', abbr: '熊市' },
+  'recession':       { en: 'Recession', zh: '经济衰退', abbr: '衰退' },
+  'inflation':       { en: 'Inflation', zh: '通胀', abbr: '通胀' },
+  'deflation':       { en: 'Deflation', zh: '通缩', abbr: '通缩' },
+  'stagflation':     { en: 'Stagflation', zh: '滞胀', abbr: '滞胀' },
+  'risk_off':        { en: 'Risk-Off', zh: '风险规避', abbr: 'Risk-Off' },
+  'risk_on':         { en: 'Risk-On', zh: '风险偏好', abbr: 'Risk-On' },
+  // Layer labels
+  'Air Activity':    { en: 'Air Activity', zh: '空中活动', abbr: '空中' },
+  'SDR Coverage':    { en: 'SDR Coverage', zh: 'SDR 覆盖', abbr: 'SDR' },
+  'Maritime Watch':  { en: 'Maritime Watch', zh: '海上监控', abbr: '海上' },
+  'Nuclear Sites':   { en: 'Nuclear Sites', zh: '核电站监测', abbr: '核监测' },
+  'Health Watch':    { en: 'Health Watch', zh: '公共卫生监测', abbr: '卫生' },
+  'OSINT Feed':      { en: 'OSINT Feed', zh: '开源情报', abbr: 'OSINT' },
+  'Space Activity':  { en: 'Space Activity', zh: '太空活动', abbr: '太空' },
+};
+
+/**
+ * Get bilingual label for a metric/source ID
+ * @param {string} id - Metric ID (e.g., 'VIXCLS', 'wti', 'GDELT')
+ * @returns {{ en: string, zh: string, abbr: string }}
+ */
+export function bilingualLabel(id) {
+  const info = METRIC_LABELS[id];
+  if (info) return info;
+  return { en: id, zh: id, abbr: id };
+}
+
+/**
+ * Translate text using MiniMax-M2.7 with caching
+ * @param {string} text - Text to translate
+ * @param {string} context - Translation context hint
+ * @returns {Promise<string>} Chinese translation
+ */
+export async function translateText(text, context = '') {
+  if (!text?.trim()) return '';
+  
+  const cacheKey = `${context}:${text.slice(0, 200)}`;
+  if (_cache.has(cacheKey)) return _cache.get(cacheKey);
+  
+  const provider = getLLMProvider();
+  if (!provider?.isConfigured) {
+    return ''; // No LLM configured, skip translation
+  }
+  
+  const systemPrompt = `You are a professional financial and geopolitical translator.
+Translate English to Simplified Chinese (zh-CN).
+Rules:
+1. Metric/indicator names: keep English + Chinese in parentheses on first occurrence
+2. Country names: use official Chinese translations
+3. Organization names: use known Chinese names (IMF→国际货币基金组织, OPEC→欧佩克, NATO→北约, WHO→世界卫生组织)
+4. Market terms: translate standard terms (bull market→牛市, bear market→熊市, spread→利差)
+5. Technical terms: translate with brief explanation
+6. Return ONLY the Chinese translation, no quotes, no explanation
+7. Keep person names and proper nouns in original form when no standard Chinese exists
+8. If translation fails, return empty string`;
+
+  try {
+    const result = await provider.complete(systemPrompt, text, { maxTokens: 400 });
+    const zh = result.text.trim();
+    
+    // LRU eviction
+    if (_cache.size >= MAX_CACHE) {
+      const firstKey = _cache.keys().next().value;
+      _cache.delete(firstKey);
+    }
+    _cache.set(cacheKey, zh);
+    return zh;
+  } catch (err) {
+    console.warn(`[Translator] Failed: "${text.slice(0,50)}..." — ${err.message}`);
+    return '';
+  }
+}
+
+/**
+ * Batch translate texts (parallel, with concurrency limit)
+ * @param {string[]} texts
+ * @param {string} context
+ * @returns {Promise<string[]>} Chinese translations (parallel order)
+ */
+export async function translateBatch(texts, context = '') {
+  const CONCURRENCY = 4;
+  const results = new Array(texts.length).fill('');
+  const pending = [];
+  
+  for (let i = 0; i < texts.length; i++) {
+    if (!texts[i]?.trim()) { results[i] = ''; continue; }
+    pending.push({ idx: i, text: texts[i] });
+  }
+  
+  for (let i = 0; i < pending.length; i += CONCURRENCY) {
+    const batch = pending.slice(i, i + CONCURRENCY);
+    const resolved = await Promise.all(
+      batch.map(({ idx, text }) => translateText(text, context))
+    );
+    resolved.forEach((zh, j) => { results[batch[j].idx] = zh; });
+  }
+  
+  return results;
+}
+
+/**
+ * Translate dashboard V2 data object in-place
+ * Adds _zh suffix fields for all user-facing strings that were translated
+ * @param {object} V2 - Synthesized dashboard data (modified in place)
+ * @returns {Promise<object>} The same V2 object (mutated)
+ */
+export async function translateDashboard(V2) {
+  const lang = process.env.CRUCIX_LANG || 'en';
+  if (lang !== 'zh') return V2; // Only translate when zh mode is active
+  
+  const provider = getLLMProvider();
+  if (!provider?.isConfigured) {
+    console.warn('[Translator] LLM not configured, skipping real-time translation');
+    return V2;
+  }
+
+  console.log('[Translator] Starting bilingual translation via MiniMax-M2.7...');
+  const start = Date.now();
+
+  // === 1. Translate FRED indicator labels ===
+  const fredItems = V2.fred || [];
+  const fredLabels = fredItems.map(f => f.label);
+  const translatedFredLabels = await translateBatch(fredLabels, 'economic indicator name');
+  fredItems.forEach((f, i) => {
+    f.labelZh = translatedFredLabels[i] || f.label;
+  });
+
+  // === 2. Translate GDELT news headlines ===
+  const gdeltTitles = V2.gdelt?.topTitles || [];
+  const translatedTitles = await translateBatch(gdeltTitles, 'news headline');
+  gdeltTitles.forEach((t, i) => {
+    if (V2.gdelt?.topTitles) V2.gdelt.topTitles[i] = { original: t, zh: translatedTitles[i] || t };
+  });
+
+  // === 3. Translate WHO alert titles ===
+  const whoAlerts = V2.who || [];
+  const whoTitles = whoAlerts.map(w => w.title);
+  const translatedWho = await translateBatch(whoTitles, 'disease alert');
+  whoAlerts.forEach((w, i) => {
+    w.titleZh = translatedWho[i] || w.title;
+    w.summaryZh = w.summary ? (translateText(w.summary, 'disease alert summary') || '') : '';
+  });
+
+  // === 4. Translate defense contract descriptions ===
+  const defenseItems = V2.defense || [];
+  const defenseDescs = defenseItems.map(c => c.desc);
+  const translatedDefense = await translateBatch(defenseDescs, 'government contract');
+  defenseItems.forEach((c, i) => {
+    c.descZh = translatedDefense[i] || c.desc;
+  });
+
+  // === 5. Translate news feed headlines ===
+  const newsFeed = V2.newsFeed || [];
+  const newsHeadlines = newsFeed.map(n => n.headline);
+  const translatedNews = await translateBatch(newsHeadlines, 'intelligence headline');
+  newsFeed.forEach((n, i) => {
+    n.headlineZh = translatedNews[i] || n.headline;
+  });
+
+  // === 6. Translate Telegram urgent posts ===
+  const tgPosts = V2.tg?.urgent || [];
+  const tgTexts = tgPosts.map(p => p.text);
+  const translatedTg = await translateBatch(tgTexts, 'OSINT telegram post');
+  tgPosts.forEach((p, i) => {
+    p.textZh = translatedTg[i] || p.text;
+  });
+
+  // === 7. Translate NOAA alert headlines ===
+  const noaaAlerts = V2.noaa?.alerts || [];
+  const noaaHeadlines = noaaAlerts.map(a => a.headline);
+  const translatedNoaa = await translateBatch(noaaHeadlines, 'weather alert');
+  noaaAlerts.forEach((a, i) => {
+    a.headlineZh = translatedNoaa[i] || a.headline;
+  });
+
+  // === 8. Translate space launch names ===
+  const launches = V2.space?.recentLaunches || [];
+  const launchNames = launches.map(l => l.name);
+  const translatedLaunches = await translateBatch(launchNames, 'space launch name');
+  launches.forEach((l, i) => {
+    l.nameZh = translatedLaunches[i] || l.name;
+  });
+
+  // === 9. Translate idea titles (if LLM ideas exist) ===
+  if (V2.ideas?.length) {
+    const ideaTitles = V2.ideas.map(idea => idea.title);
+    const translatedIdeas = await translateBatch(ideaTitles, 'trading idea');
+    V2.ideas.forEach((idea, i) => {
+      idea.titleZh = translatedIdeas[i] || idea.title;
+    });
+  }
+
+  const elapsed = Date.now() - start;
+  console.log(`[Translator] Done — ${Object.keys(_cache).length} cached, ${elapsed}ms`);
+  
+  return V2;
+}
+
+/**
+ * Check translator health
+ * @returns {Promise<{ok: boolean, model: string, cacheSize: number}>}
+ */
+export async function check() {
+  try {
+    const provider = getLLMProvider();
+    if (!provider?.isConfigured) {
+      return { ok: false, reason: 'LLM not configured', model: null, cacheSize: 0 };
+    }
+    // Quick test
+    const test = await provider.complete(
+      'You are a test assistant. Reply with exactly: OK',
+      'Reply OK',
+      { maxTokens: 10 }
+    );
+    return {
+      ok: test.text.trim() === 'OK',
+      model: provider.model || 'MiniMax-M2.7',
+      cacheSize: _cache.size,
+    };
+  } catch (err) {
+    return { ok: false, reason: err.message, model: null, cacheSize: _cache.size };
+  }
+}
+
+// Export cache stats for debugging
+export function cacheStats() {
+  return { size: _cache.size, max: MAX_CACHE };
+}

--- a/lib/translation/llm.mjs
+++ b/lib/translation/llm.mjs
@@ -1,0 +1,133 @@
+// MiniMax LLM client for Crucix translation service
+// Uses MiniMax-M2.7 via api.minimaxi.com
+
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+
+// Load env vars if not already loaded
+try { require('../../.env'); } catch {}
+
+const API_KEY = process.env.LLM_API_KEY;
+const API_BASE = 'https://api.minimaxi.com/v1';
+const MODEL = 'MiniMax-M2.7';
+
+if (!API_KEY) {
+  console.warn('[MiniMax] LLM_API_KEY not set — translation will be disabled');
+}
+
+/**
+ * Translate text from English to Chinese using MiniMax-M2.7
+ * @param {string} text - English text to translate
+ * @param {object} opts - Translation options
+ * @returns {Promise<{zh: string, en: string, hint: string}>}
+ */
+export async function translate(text, opts = {}) {
+  if (!API_KEY) {
+    throw new Error('MiniMax API key not configured');
+  }
+  if (!text || text.trim().length === 0) {
+    return { zh: '', en: text, hint: '' };
+  }
+
+  const { context = '', maxTokens = 200 } = opts;
+
+  const systemPrompt = `You are a professional financial and geopolitical translator.
+When translating, follow these rules:
+1. Keep metric names in English but provide Chinese parenthetical: "CPI (消费者价格指数)"
+2. Country names: prefer official Chinese names: "United States" → "美国", "Russia" → "俄罗斯"
+3. Organization names: known Chinese names: "IMF" → "国际货币基金组织", "OPEC" → "欧佩克"
+4. Market terms: "bear market" → "熊市", "bull market" → "牛市", "spread" → "利差"
+5. Technical terms: translate with brief explanation in parentheses when first introduced
+6. Event descriptions: translate faithfully, do not add opinions
+7. Keep proper nouns (names, locations) in original form when no standard Chinese translation exists
+8. Return ONLY valid JSON: {"zh": "...", "hint": "..."} with no markdown or extra text
+9. zh field should be the full Chinese translation
+10. hint field should be a very brief parenthetical in Chinese for the first appearance`;
+
+  const userPrompt = context
+    ? `Context: ${context}\n\nTranslate this to Chinese:\n${text}`
+    : `Translate to Chinese:\n${text}`;
+
+  try {
+    const response = await fetch(`${API_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userPrompt },
+        ],
+        max_tokens: maxTokens,
+        temperature: 0.3,
+      }),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`MiniMax API error ${response.status}: ${err}`);
+    }
+
+    const data = await response.json();
+    const raw = data.choices?.[0]?.message?.content?.trim() || '';
+
+    // Extract JSON from response (handle potential markdown code blocks)
+    let jsonStr = raw;
+    const jsonMatch = raw.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      jsonStr = jsonMatch[0];
+    }
+
+    const parsed = JSON.parse(jsonStr);
+    return {
+      zh: parsed.zh || '',
+      en: text,
+      hint: parsed.hint || '',
+    };
+  } catch (err) {
+    console.error(`[MiniMax] Translation failed for "${text.substring(0, 50)}...":`, err.message);
+    // Fallback: return original with empty translation
+    return { zh: '', en: text, hint: '' };
+  }
+}
+
+/**
+ * Batch translate multiple texts efficiently
+ * @param {string[]} texts - Array of English texts
+ * @param {object} opts - Translation options
+ * @returns {Promise<Array<{zh: string, en: string, hint: string}>>}
+ */
+export async function translateBatch(texts, opts = {}) {
+  // Process in parallel with concurrency limit
+  const CONCURRENCY = 5;
+  const results = [];
+  
+  for (let i = 0; i < texts.length; i += CONCURRENCY) {
+    const batch = texts.slice(i, i + CONCURRENCY);
+    const batchResults = await Promise.all(
+      batch.map(t => translate(t, opts))
+    );
+    results.push(...batchResults);
+  }
+  
+  return results;
+}
+
+/**
+ * Check if MiniMax API is accessible
+ * @returns {Promise<boolean>}
+ */
+export async function healthCheck() {
+  if (!API_KEY) return false;
+  try {
+    const resp = await fetch(`${API_BASE}/models`, {
+      headers: { 'Authorization': `Bearer ${API_KEY}` },
+    });
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1,0 +1,360 @@
+{
+  "meta": {
+    "code": "zh",
+    "name": "中文",
+    "nativeName": "中文"
+  },
+  "dashboard": {
+    "title": "CRUCIX — 情报终端",
+    "bootTitle": "CRUCIX 情报引擎",
+    "bootSubtitle": "本地版 Palantir · 31 个情报源",
+    "waitingForSweep": "等待首次扫描完成...",
+    "sourcesOk": "情报源正常",
+    "lastSweep": "最近扫描",
+    "nextSweep": "下次扫描",
+    "sweep": "扫描",
+    "sources": "情报源",
+    "delta": "变化",
+    "highAlert": "高度警报",
+    "riskOff": "风险规避",
+    "riskOn": "风险偏好",
+    "mixed": "混合信号",
+    "terminalActive": "终端活跃",
+    "perf": "性能",
+    "perfLow": "低",
+    "perfHigh": "高",
+    "guideBtn": "信号含义说明"
+  },
+  "boot": {
+    "initializing": "正在初始化 CRUCIX 引擎 v2.1.0",
+    "connecting": "正在连接 {count} 个开源情报源...",
+    "sourceGroup1": "OPENSKY · FIRMS · KIWISDR · 船运",
+    "sourceGroup2": "FRED · BLS · EIA · 财政部 · GSCPI",
+    "sourceGroup3": "Telegram · Safecast · EPA · WHO · OFAC",
+    "sourceGroup4": "GDELT · NOAA · 专利 · Bluesky · Reddit",
+    "sourceGroup5": "USGS · ECB · CVE · Copernicus · CelesTrak",
+    "sweepComplete": "扫描完成 — {ok}/{total} 个情报源正常",
+    "ok": "正常",
+    "acledLayer": "冲突数据图层",
+    "events": "事件",
+    "degraded": "降级",
+    "flightCorridors": "空中走廊",
+    "active": "活跃",
+    "dualProjection": "双投影",
+    "ready": "就绪",
+    "intelligenceSynthesis": "情报综合"
+  },
+  "panels": {
+    "sensorGrid": "传感器网格",
+    "tradeIdeas": "交易思路",
+    "osintFeed": "开源情报流",
+    "osintStream": "开源情报流",
+    "nuclearWatch": "核武监控",
+    "newsTicker": "新闻滚动",
+    "sweepDelta": "扫描变化",
+    "macroMarkets": "宏观+市场",
+    "healthAlerts": "健康警报",
+    "riskGauges": "风险仪表",
+    "crossSourceSignals": "跨域信号",
+    "signalCore": "信号核心",
+    "seismicWatch": "地震监控",
+    "cyberWatch": "网络监控",
+    "spaceWatch": "太空监控",
+    "europeAlerts": "欧洲警报",
+    "ecbIndicators": "欧洲央行指标"
+  },
+  "layers": {
+    "airActivity": "空中活动",
+    "thermalSpikes": "热异常",
+    "sdrCoverage": "SDR 覆盖",
+    "maritimeWatch": "海运监控",
+    "nuclearSites": "核设施",
+    "conflictEvents": "冲突事件",
+    "healthWatch": "健康监控",
+    "worldNews": "全球新闻",
+    "osintFeed": "开源情报",
+    "theaters": "战区",
+    "nightDet": "夜视探测",
+    "online": "在线",
+    "chokepoints": "咽喉要道",
+    "monitors": "监控点",
+    "fatalities": "伤亡",
+    "whoAlerts": "世卫警报",
+    "rssGeolocated": "定位新闻",
+    "earthquakes": "地震",
+    "seismicEvents": "地震事件",
+    "cyberVulns": "网络漏洞",
+    "spaceActivity": "太空活动",
+    "europeEmergency": "欧洲紧急",
+    "orbital": "轨道卫星"
+  },
+  "map": {
+    "worldNews": "全球新闻",
+    "healthAlert": "健康警报",
+    "chokepoint": "咽喉要道",
+    "nuclearSite": "核设施",
+    "osintEvent": "情报事件",
+    "thermalDetection": "热源探测",
+    "aircraft": "飞行器",
+    "rssGeolocated": "定位新闻",
+    "airTraffic": "空中交通",
+    "thermalFire": "火灾热源",
+    "conflict": "冲突",
+    "sdrReceiver": "SDR 接收器",
+    "scrollToZoom": "滚动缩放",
+    "globeMode": "地球模式",
+    "flatMode": "地图模式",
+    "earthquake": "地震",
+    "disaster": "灾害",
+    "weatherAlert": "天气警报",
+    "epaRadNet": "辐射监测",
+    "spaceStation": "空间站",
+    "gdeltEvent": "GDELT 事件"
+  },
+  "ideas": {
+    "confidence": "置信度",
+    "horizon": "时间窗口",
+    "risk": "风险",
+    "signals": "信号",
+    "rationale": "逻辑",
+    "aiEnhanced": "AI 增强",
+    "llmOff": "规则引擎生成",
+    "pending": "等待分析",
+    "llmNotConfigured": "未配置 AI",
+    "llmHelp": "配置 AI 提供商以启用智能交易思路",
+    "disclosure": "免责声明"
+  },
+  "regions": {
+    "world": "全球",
+    "americas": "美洲",
+    "europe": "欧洲",
+    "middleEast": "中东",
+    "asiaPacific": "亚太",
+    "africa": "非洲"
+  },
+  "badges": {
+    "radiation": "辐射",
+    "live": "实时",
+    "delayed": "延迟",
+    "items": "项目",
+    "urgent": "紧急",
+    "worldview": "世界观",
+    "hotMetrics": "热点指标",
+    "stress": "压力",
+    "sweeping": "扫描中",
+    "europe": "欧洲",
+    "orbital": "轨道"
+  },
+  "delta": {
+    "baseline": "基准",
+    "escalation": "升级",
+    "deescalation": "降级",
+    "stable": "稳定",
+    "newSignals": "新信号",
+    "resolved": "已解决",
+    "noChanges": "无变化",
+    "changes": "变化",
+    "critical": "危急",
+    "new": "新增"
+  },
+  "metrics": {
+    "wtiCrude": "WTI 原油",
+    "brent": "布伦特原油",
+    "natGas": "天然气",
+    "vix": "VIX 恐慌指数",
+    "fedFunds": "美联储利率",
+    "gscpi": "全球供应链压力",
+    "cpiMom": "CPI 月环比",
+    "unemployment": "失业率",
+    "hySpread": "高收益利差",
+    "usdIndex": "美元指数",
+    "joblessClaims": "初请失业金",
+    "mortgage30y": "30 年抵押贷款利率",
+    "m2Supply": "M2 货币供应",
+    "natDebt": "国债",
+    "wti5day": "WTI 5 日变化",
+    "indexes": "指数",
+    "crypto": "加密货币",
+    "energyMacro": "能源+宏观",
+    "vsPrior": "vs 前值",
+    "ecbRate": "欧央行利率",
+    "eurusd": "欧元/美元",
+    "euM3": "欧元区 M3",
+    "euHicp": "欧元区 HICP",
+    "earthquakes7d": "7 日地震",
+    "criticalCves": "严重漏洞",
+    "spaceObjects": "太空物体",
+    "starlink": "星链卫星",
+    "europeAlerts": "欧洲警报"
+  },
+  "signalMetrics": {
+    "incidentTempo": "事件频率",
+    "airTheaters": "空中战区",
+    "thermalSpikes": "热异常",
+    "sdrNodes": "SDR 节点",
+    "chokepoints": "咽喉要道",
+    "whoAlerts": "世卫警报"
+  },
+  "nuclear": {
+    "allSitesNormal": "全部站点正常",
+    "anomalyDetected": "检测到异常",
+    "noData": "无数据"
+  },
+  "seismic": {
+    "noRecentQuakes": "近期无显著地震",
+    "majorQuake": "大型地震",
+    "tsunamiRisk": "海啸风险",
+    "mag": "震级"
+  },
+  "cyber": {
+    "noAlerts": "无警报",
+    "criticalAlert": "严重警报",
+    "cvss": "CVSS",
+    "critical": "严重"
+  },
+  "space": {
+    "noActivity": "无活动",
+    "launchDetected": "检测到发射",
+    "objectsTracked": "追踪中",
+    "newLast30d": "30 日内新增",
+    "satellites": "卫星",
+    "recentLaunches": "近期发射",
+    "totalTracked": "总追踪数",
+    "byCountry": "按国家",
+    "constellations": "星座",
+    "launches": "发射"
+  },
+  "europe": {
+    "noAlerts": "无欧洲警报",
+    "activeAlerts": "活跃警报",
+    "fires": "火灾",
+    "floods": "洪水",
+    "types": "类型"
+  },
+  "time": {
+    "justNow": "刚刚",
+    "hoursAgo": "{n} 小时前",
+    "daysAgo": "{n} 天前"
+  },
+  "bot": {
+    "commands": {
+      "status": "状态",
+      "sweep": "扫描",
+      "brief": "简报",
+      "portfolio": "持仓",
+      "alerts": "警报",
+      "mute": "静音",
+      "unmute": "取消静音",
+      "help": "帮助"
+    },
+    "messages": {
+      "alertsMuted": "警报已静音",
+      "useUnmute": "使用 /unmute 恢复",
+      "alertsResumed": "警报已恢复",
+      "sweepTriggered": "已触发扫描",
+      "sweepInProgress": "扫描进行中...",
+      "noDataYet": "暂无数据",
+      "noRecentAlerts": "近期无警报",
+      "recentAlerts": "近期警报",
+      "commandsTip": "输入 /help 查看所有命令",
+      "commandFailed": "命令执行失败",
+      "portfolioNotAvailable": "暂无持仓数据"
+    },
+    "status": {
+      "title": "系统状态",
+      "uptime": "运行时间",
+      "lastSweep": "最近扫描",
+      "nextSweep": "下次扫描",
+      "sweepInProgress": "扫描中",
+      "yes": "是",
+      "no": "否",
+      "sources": "情报源",
+      "failed": "失败",
+      "llm": "AI 分析",
+      "enabled": "已启用",
+      "disabled": "已禁用",
+      "sseClients": "Dashboard 连接",
+      "dashboard": "Dashboard",
+      "pending": "等待中",
+      "never": "从未"
+    },
+    "brief": {
+      "title": "情报简报",
+      "direction": "方向",
+      "changes": "变化",
+      "criticalChanges": "重大变化",
+      "osint": "开源情报",
+      "urgentSignals": "紧急信号",
+      "totalPosts": "情报帖子总数",
+      "topIdeas": "重点思路"
+    },
+    "alertTiers": {
+      "flash": "紧急",
+      "priority": "重要",
+      "routine": "常规"
+    }
+  },
+  "alerts": {
+    "tiers": {
+      "flash": {
+        "label": "紧急",
+        "description": "立即行动"
+      },
+      "priority": {
+        "label": "重要",
+        "description": "需关注"
+      },
+      "routine": {
+        "label": "常规",
+        "description": "例行监控"
+      }
+    },
+    "confidence": {
+      "high": "高",
+      "medium": "中",
+      "low": "低"
+    },
+    "fields": {
+      "direction": "方向",
+      "confidence": "置信度",
+      "crossCorrelation": "跨域关联",
+      "action": "建议",
+      "signals": "信号",
+      "monitor": "监控"
+    },
+    "messages": {
+      "alertsMuted": "警报已静音",
+      "mutedUntil": "静音至 {time}",
+      "useUnmuteToResume": "使用 /unmute 取消静音",
+      "alertsResumed": "警报已恢复",
+      "willReceiveNext": "下次有新警报时通知你"
+    },
+    "ruleBasedHeadlines": {
+      "nuclearAnomaly": "核监测异常",
+      "crossDomainSignals": "跨域信号关联",
+      "escalatingSignals": "信号升级中",
+      "osintSurge": "开源情报激增",
+      "signalChangeDetected": "检测到信号变化"
+    }
+  },
+  "discord": {
+    "commands": {
+      "status": "状态",
+      "sweep": "扫描",
+      "brief": "简报",
+      "portfolio": "持仓",
+      "alerts": "警报",
+      "mute": "静音",
+      "unmute": "取消静音",
+      "muteHoursOption": "静音时长（小时）"
+    }
+  },
+  "llm": {
+    "systemPrompt": "你是 Crucix 情报助手。当前的 UI 语言为中文。"
+  },
+  "api": {
+    "errors": {
+      "noDataYet": "暂无数据，请等待首次扫描完成"
+    }
+  }
+}

--- a/server.mjs
+++ b/server.mjs
@@ -14,6 +14,7 @@ import { synthesize, generateIdeas } from './dashboard/inject.mjs';
 import { MemoryManager } from './lib/delta/index.mjs';
 import { createLLMProvider } from './lib/llm/index.mjs';
 import { generateLLMIdeas } from './lib/llm/ideas.mjs';
+import { translateDashboard, check as checkTranslator } from './lib/translation/index.mjs';
 import { TelegramAlerter } from './lib/alerts/telegram.mjs';
 import { DiscordAlerter } from './lib/alerts/discord.mjs';
 
@@ -380,6 +381,17 @@ async function runSweepCycle() {
     memory.pruneAlertedSignals();
 
     currentData = synthesized;
+
+    // 7. Bilingual translation via MiniMax-M2.7 (only when CRUCIX_LANG=zh)
+    if (process.env.CRUCIX_LANG === 'zh' && llmProvider?.isConfigured) {
+      try {
+        const langStart = Date.now();
+        await translateDashboard(currentData);
+        console.log(`[Crucix] Translation done in ${Date.now() - langStart}ms`);
+      } catch (transErr) {
+        console.warn('[Crucix] Translation failed (non-fatal):', transErr.message);
+      }
+    }
 
     // 6. Push to all connected browsers
     broadcast({ type: 'update', data: currentData });


### PR DESCRIPTION
## Summary

Add Chinese (zh) locale with 282 UI label translations + real-time data translation via MiniMax-M2.7.

## Changes

### Static UI Labels
- **locales/zh.json** — 282 translated strings (panel names, map layers, bot commands, alert tiers)
- **lib/i18n.mjs** — add 'zh' to SUPPORTED_LOCALES array

### Real-Time Data Translation (MiniMax-M2.7)
- **lib/translation/llm.mjs** — MiniMax client with proper `api.minimaxi.com` endpoint
- **lib/translation/index.mjs** — translateDashboard() service with LRU cache
  - Bilingual metric labels: static table (no LLM call) for FRED/VIX/M2/CPI etc.
  - Dynamic translation: GDELT headlines, WHO alerts, defense contracts, news feed, Telegram posts, NOAA alerts, space launches
- **lib/llm/minimax.mjs** — fix endpoint from `api.minimax.io` → `api.minimaxi.com`
- **lib/llm/index.mjs** — pass apiBase to MiniMaxProvider
- **server.mjs** — integrate translateDashboard after synthesis (CRUCIX_LANG=zh mode)

## Usage

```bash
# Static UI only (no LLM)
CRUCIX_LANG=zh

# Full bilingual dashboard (requires MiniMax API key)
CRUCIX_LANG=zh
LLM_PROVIDER=minimax
LLM_API_KEY=your_key_here
LLM_MODEL=MiniMax-M2.7
```

## Environment

| Variable | Required | Description |
|----------|----------|-------------|
| `CRUCIX_LANG` | Yes (for zh) | Set to `zh` to enable Chinese UI + translation |
| `LLM_API_KEY` | Yes (for zh) | MiniMax API key from platform.minimaxi.com |
| `LLM_PROVIDER` | Yes | `minimax` |
| `LLM_MODEL` | No | Defaults to `MiniMax-M2.7` |

---
*Maintained by @xujiasteven*