### PR TITLE
feat(i18n): full Chinese (zh) localization with DeepSeek LLM translation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,15 +30,17 @@ CLOUDFLARE_API_TOKEN=
 PORT=3117
 # Auto-refresh interval (minutes)
 REFRESH_INTERVAL_MINUTES=15
+# Interface language: en | fr | zh
+CRUCIX_LANG=
 
 # === LLM Layer (optional) ===
 # Enables AI-enhanced trade ideas and breaking news Telegram alerts.
-# Provider options: anthropic | openai | gemini | codex | openrouter | minimax | mistral | ollama | grok
+# Provider options: anthropic | openai | gemini | codex | openrouter | minimax | mistral | ollama | grok | deepseek
 LLM_PROVIDER=
 # Not needed for codex (uses ~/.codex/auth.json) or ollama (local)
 LLM_API_KEY=
 # Optional override. Each provider has a sensible default:
-# anthropic: claude-sonnet-4-6 | openai: gpt-5.4 | gemini: gemini-3.1-pro | codex: gpt-5.3-codex | openrouter: openrouter/auto | minimax: MiniMax-M2.5 | ollama: llama3.1:8b | grok: grok-4-latest
+# anthropic: claude-sonnet-4-6 | openai: gpt-5.4 | gemini: gemini-3.1-pro | codex: gpt-5.3-codex | openrouter: openrouter/auto | minimax: MiniMax-M2.5 | ollama: llama3.1:8b | grok: grok-4-latest | deepseek: deepseek-chat
 LLM_MODEL=
 # Ollama base URL (only needed if not using default http://localhost:11434)
 OLLAMA_BASE_URL=

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Copy package files first for better layer caching
 COPY package*.json ./
-RUN npm install --production
+RUN npm install --omit=dev
 
 # Copy source
 COPY . .

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ These three unlock the most valuable economic and satellite data. Each takes abo
 
 ### LLM Provider (optional, for AI-enhanced ideas)
 
-Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, `grok`
+Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, `grok`, `deepseek`
 
 | Provider | Key Required | Default Model |
 |----------|-------------|---------------|
@@ -234,6 +234,7 @@ Set `LLM_PROVIDER` to one of: `anthropic`, `openai`, `gemini`, `codex`, `openrou
 | `minimax` | `LLM_API_KEY` | MiniMax-M2.5 |
 | `mistral` | `LLM_API_KEY` | mistral-large-latest |
 | `grok` | `LLM_API_KEY` | grok-4-latest |
+| `deepseek` | `LLM_API_KEY` | deepseek-chat |
 
 For Codex, run `npx @openai/codex login` to authenticate via your ChatGPT subscription.
 
@@ -414,7 +415,8 @@ All settings are in `.env` with sensible defaults:
 |----------|---------|-------------|
 | `PORT` | `3117` | Dashboard server port |
 | `REFRESH_INTERVAL_MINUTES` | `15` | Auto-refresh interval |
-| `LLM_PROVIDER` | disabled | `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, or `grok` |
+| `CRUCIX_LANG` | `en` | Interface language: `en`, `fr`, or `zh` |
+| `LLM_PROVIDER` | disabled | `anthropic`, `openai`, `gemini`, `codex`, `openrouter`, `minimax`, `mistral`, `grok`, or `deepseek` |
 | `LLM_API_KEY` | — | API key (not needed for codex) |
 | `LLM_MODEL` | per-provider default | Override model selection |
 | `TELEGRAM_BOT_TOKEN` | disabled | For Telegram alerts + bot commands |

--- a/crucix.config.mjs
+++ b/crucix.config.mjs
@@ -7,7 +7,7 @@ export default {
   refreshIntervalMinutes: parseInt(process.env.REFRESH_INTERVAL_MINUTES) || 15,
 
   llm: {
-    provider: process.env.LLM_PROVIDER || null, // anthropic | openai | gemini | codex | openrouter | minimax | mistral | ollama | grok
+    provider: process.env.LLM_PROVIDER || null, // anthropic | openai | gemini | codex | openrouter | minimax | mistral | ollama | grok | deepseek
     apiKey: process.env.LLM_API_KEY || null,
     model: process.env.LLM_MODEL || null,
     baseUrl: process.env.OLLAMA_BASE_URL || null,

--- a/dashboard/inject.mjs
+++ b/dashboard/inject.mjs
@@ -10,6 +10,7 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { exec } from 'child_process';
 import config from '../crucix.config.mjs';
+import { getLocale, currentLanguage } from '../lib/i18n.mjs';
 import { createLLMProvider } from '../lib/llm/index.mjs';
 import { generateLLMIdeas } from '../lib/llm/ideas.mjs';
 
@@ -729,6 +730,11 @@ async function cliInject() {
   let html = readFileSync(htmlPath, 'utf8');
   // Use a replacer function so JSON is inserted literally even if it contains `$`.
   html = html.replace(/^(let|const) D = .*;\s*$/m, () => 'let D = ' + json + ';');
+  // Inject locale data
+  const locale = getLocale();
+  const localeScript = `<script>window.__CRUCIX_LOCALE__ = ${JSON.stringify(locale).replace(/<\/script>/gi, '<\\/script>')};</script>`;
+  html = html.replace('</head>', `${localeScript}\n</head>`);
+  html = html.replace('<html lang="en">', `<html lang="${currentLanguage}">`);
   writeFileSync(htmlPath, html);
   console.log('Data injected into jarvis.html!');
 

--- a/dashboard/public/jarvis.html
+++ b/dashboard/public/jarvis.html
@@ -340,15 +340,15 @@ body.low-perf .ticker-wrap::-webkit-scrollbar-thumb{background:rgba(100,240,200,
       <div class="map-container" id="mapContainer">
         <div id="globeViz"></div>
         <svg id="flatMapSvg" style="display:none;width:100%;height:100%;position:absolute;top:0;left:0;cursor:grab"></svg>
-        <div class="map-loading" id="mapLoading"><div class="map-loading-card"><div class="map-loading-ring"></div><div class="map-loading-text" id="mapLoadingText">Initializing 3D Globe</div></div></div>
+        <div class="map-loading" id="mapLoading"><div class="map-loading-card"><div class="map-loading-ring"></div><div class="map-loading-text" id="mapLoadingText">${t('map.initializing','Initializing 3D Globe')}</div></div></div>
         <div class="map-legend" id="mapLegend"></div>
-        <div class="map-hint" id="mapHint">SCROLL TO ZOOM · DRAG TO PAN</div>
+        <div class="map-hint" id="mapHint">${t('map.scrollToZoom','SCROLL TO ZOOM · DRAG TO PAN')}</div>
         <div class="map-controls">
           <button class="map-ctrl-btn" onclick="mapZoom(1.5)" title="Zoom in">+</button>
           <button class="map-ctrl-btn" onclick="mapZoom(0.67)" title="Zoom out">&minus;</button>
           <button class="map-ctrl-btn map-toggle" id="flightToggle" onclick="toggleFlights()" title="Toggle flight routes">&#9992;</button>
         </div>
-        <button class="proj-toggle" id="projToggle" onclick="toggleMapMode()">GLOBE MODE</button>
+        <button class="proj-toggle" id="projToggle" onclick="toggleMapMode()">${t('map.globeMode','GLOBE MODE')}</button>
         <div class="map-popup" id="mapPopup"><button class="pp-close" onclick="closePopup()">&times;</button><div class="pp-head"></div><div class="pp-text"></div><div class="pp-meta"></div></div>
       </div>
       <div class="lower" id="lowerGrid"></div>
@@ -360,14 +360,14 @@ body.low-perf .ticker-wrap::-webkit-scrollbar-thumb{background:rgba(100,240,200,
   <div class="glossary-panel">
     <div class="glossary-head">
       <div>
-        <div class="glossary-kicker">Signal Guide</div>
-        <div class="glossary-title">What the signals actually mean</div>
-        <div class="glossary-sub">Plain-English interpretation, why it matters, and what you should not infer from it.</div>
+        <div class="glossary-kicker">${t('glossary.kicker','Signal Guide')}</div>
+        <div class="glossary-title">${t('glossary.title','What the signals actually mean')}</div>
+        <div class="glossary-sub">${t('glossary.subtitle','Plain-English interpretation, why it matters, and what you should not infer from it.')}</div>
       </div>
       <button class="glossary-close" onclick="closeGlossary()" aria-label="Close signal guide">&times;</button>
     </div>
     <div class="glossary-body" id="glossaryBody"></div>
-    <div class="glossary-foot">Treat these as interpretation guides, not conclusions. Stronger judgments should come from corroboration across multiple layers, not from a single signal viewed in isolation.</div>
+    <div class="glossary-foot">${t('glossary.foot','Treat these as interpretation guides, not conclusions. Stronger judgments should come from corroboration across multiple layers, not from a single signal viewed in isolation.')}</div>
   </div>
 </div>
 <script>
@@ -396,120 +396,7 @@ let lowPerfMode = localStorage.getItem('crucix_low_perf') === 'true';
 let isFlat = shouldStartFlat();
 let currentRegion = 'world';
 let flatSvg, flatProjection, flatPath, flatG, flatZoom, flatW, flatH;
-const signalGuideItems = [
-  {
-    term:'No Callsign',
-    category:'Air',
-    meaning:'OpenSky received an aircraft track without a usable callsign or flight ID in that record.',
-    matters:'Useful as an opacity signal. A cluster of missing callsigns can indicate incomplete transponder metadata or less transparent traffic.',
-    notMeaning:'Not proof of military, covert, or hostile activity on its own.',
-    example:'South China Sea: No Callsign 6 of 152 means 6 tracks in that theater had no usable callsign in the feed.'
-  },
-  {
-    term:'High Altitude',
-    category:'Air',
-    meaning:'Aircraft above 12,000 meters, roughly 39,000 feet, in the current OpenSky snapshot.',
-    matters:'Separates cruise-level traffic from lower-altitude local or regional movement.',
-    notMeaning:'Not a danger score and not inherently unusual. Commercial jets commonly operate here.',
-    example:'High Altitude 2 means only 2 tracked aircraft in that hotspot were above the cruise threshold at that snapshot.'
-  },
-  {
-    term:'Top Countries',
-    category:'Air',
-    meaning:'The most common OpenSky origin_country values among aircraft in that hotspot.',
-    matters:'Useful for understanding the rough composition of traffic flowing through a theater.',
-    notMeaning:'Not who is controlling the aircraft right now and not a direct indicator of military ownership.',
-    example:'China (61), Philippines (39), Taiwan (17) means those were the top registered origin countries in the snapshot.'
-  },
-  {
-    term:'FRP',
-    category:'Thermal',
-    meaning:'Fire Radiative Power. This is the intensity of one specific FIRMS hotspot, measured in megawatts.',
-    matters:'Higher FRP usually means a hotter, larger, or more energetic fire event at that exact point.',
-    notMeaning:'Not the intensity of the whole region and not automatic proof of conflict activity.',
-    example:'Sudan / Horn of Africa: FRP 92.3 MW describes that one hotspot, while Total 1,451 describes the entire regional detection count.'
-  },
-  {
-    term:'Total Detections',
-    category:'Thermal',
-    meaning:'The total number of FIRMS thermal detections in the entire region bucket for the current sweep.',
-    matters:'Useful for spotting unusually active fire clusters, especially when compared with historical baselines or night activity.',
-    notMeaning:'Not a count for the single map point you clicked and not necessarily a conflict count.',
-    example:'Total 1,451 means the whole Sudan / Horn of Africa bucket had 1,451 detections in that sweep.'
-  },
-  {
-    term:'Night Detections',
-    category:'Thermal',
-    meaning:'Thermal detections tagged as occurring at night inside the broader FIRMS region bucket.',
-    matters:'Nighttime heat can be more noteworthy because it is less likely to be routine daytime land burning.',
-    notMeaning:'Not a direct combat indicator. It still needs context from location, baseline, and corroborating sources.',
-    example:'Night 140 means 140 of the 1,451 regional detections were nighttime detections in that sweep.'
-  },
-  {
-    term:'Chokepoint',
-    category:'Maritime',
-    meaning:'A strategic maritime corridor or passage where trade and energy flows can be delayed, diverted, or disrupted.',
-    matters:'These nodes matter because a disruption here can affect shipping costs, transit times, and commodity pricing globally.',
-    notMeaning:'Not proof that disruption is happening now. It is a strategic watch location.',
-    example:'Bab el-Mandeb or the Strait of Hormuz matter because shipping and energy flows concentrate there.'
-  },
-  {
-    term:'SDR Receiver',
-    category:'Signals',
-    meaning:'A publicly reachable software-defined radio receiver in or near a region of interest.',
-    matters:'Dense receiver coverage can give you more ability to monitor communications or signal activity in a theater.',
-    notMeaning:'Not evidence of hostile emissions or a threat by itself. It is an observation and monitoring layer.',
-    example:'South China Sea SDR count means publicly accessible KiwiSDR receivers are available in or near that zone.'
-  },
-  {
-    term:'CPM',
-    category:'Radiation',
-    meaning:'Counts per minute from a radiation monitoring source, used here for relative radiation status at a site.',
-    matters:'Useful for spotting anomalies against the site’s normal range or comparing consecutive readings.',
-    notMeaning:'Not a direct safety verdict on its own. Interpretation depends on local baseline and trend, not the raw number alone.',
-    example:'A site reading 33 CPM can be normal if that location’s usual background level is in the same range.'
-  },
-  {
-    term:'HY Spread',
-    category:'Macro',
-    meaning:'High-yield credit spread, shown here as a stress proxy from FRED credit data.',
-    matters:'When spreads widen, markets are usually pricing more credit stress and tighter financial conditions.',
-    notMeaning:'Not a recession call by itself. It is one stress signal among many.',
-    example:'A rising HY Spread alongside higher VIX and weaker equities is a stronger risk-off pattern than HY alone.'
-  },
-  {
-    term:'VIX',
-    category:'Macro',
-    meaning:'The CBOE Volatility Index, commonly used as a market-implied fear or volatility gauge.',
-    matters:'Higher VIX often means more expected equity volatility and more defensive market positioning.',
-    notMeaning:'Not a direct forecast of a crash and not a geopolitical indicator by itself.',
-    example:'VIX above 20 with widening HY spreads is a stronger stress pattern than VIX alone.'
-  },
-  {
-    term:'GSCPI',
-    category:'Macro',
-    meaning:'The Global Supply Chain Pressure Index, a broad indicator of global supply-chain strain.',
-    matters:'It helps translate geopolitical or weather disruptions into likely pressure on shipping, inventory, and pricing.',
-    notMeaning:'Not a live market price and not a company-specific supply-chain score by itself.',
-    example:'A higher GSCPI makes route or energy shocks more likely to spill into broader cost pressure.'
-  },
-  {
-    term:'WHO Alert',
-    category:'Health',
-    meaning:'A WHO Disease Outbreak News item or outbreak-related bulletin surfaced in the health layer.',
-    matters:'Useful for watching outbreaks that could affect travel, supply chains, humanitarian stress, or regional operating conditions.',
-    notMeaning:'Not a pandemic declaration and not automatically high severity.',
-    example:'A WHO alert in a port-heavy region matters more if it overlaps shipping, border controls, or local instability signals.'
-  },
-  {
-    term:'Sweep Delta',
-    category:'Platform',
-    meaning:'The change summary between the current sweep and the previous one, including new, escalated, and de-escalated signals.',
-    matters:'Useful for spotting what changed recently instead of re-reading the full dashboard from scratch.',
-    notMeaning:'Not a full risk model. It is a directional change layer on top of the raw signals.',
-    example:'A delta marked risk-off with several new and escalated items means the latest sweep materially worsened the signal mix.'
-  }
-];
+const signalGuideItems = (L.glossary?.items || []);
 const regionPOV = {
   world: { lat: 20, lng: 20, altitude: 1.8 },
   americas: { lat: 35, lng: -95, altitude: 1.0 },
@@ -533,7 +420,7 @@ function shouldStartFlat(){
   return lowPerfMode || isWeakMobileDevice();
 }
 
-function setMapLoading(show, text='Initializing 3D Globe'){
+function setMapLoading(show, text=t('map.initializing','Initializing 3D Globe')){
   const overlay = document.getElementById('mapLoading');
   const label = document.getElementById('mapLoadingText');
   if(!overlay || !label) return;
@@ -562,7 +449,7 @@ function togglePerfMode(){
 // === TOPBAR ===
 function getRegionControlsMarkup(){
   return ['world','americas','europe','middleEast','asiaPacific','africa'].map(r=>
-    `<button class="region-btn ${r===currentRegion?'active':''}" data-region="${r}" onclick="setRegion('${r}')">${r==='middleEast'?'MIDDLE EAST':r==='asiaPacific'?'ASIA PACIFIC':r.toUpperCase()}</button>`
+    `<button class="region-btn ${r===currentRegion?'active':''}" data-region="${r}" onclick="setRegion('${r}')">${t('regions.'+r,r==='middleEast'?'MIDDLE EAST':r==='asiaPacific'?'ASIA PACIFIC':r.toUpperCase())}</button>`
   ).join('');
 }
 
@@ -581,7 +468,7 @@ function renderRegionControls(){
 function renderTopbar(){
   const mobile = isMobileLayout();
   const ts = new Date(D.meta.timestamp);
-  const d = ts.toLocaleDateString('en-US',{month:'short',day:'numeric',year:'numeric'}).toUpperCase();
+  const d = ts.toLocaleDateString(L.meta?.code==='zh'?'zh-CN':'en-US',{month:'short',day:'numeric',year:'numeric'}).toUpperCase();
   const timeStr = ts.toLocaleTimeString('en-US',{hour:'2-digit',minute:'2-digit',hour12:true});
   document.getElementById('topbar').innerHTML=`
     <div class="top-left">
@@ -653,14 +540,14 @@ function renderLeftRail(){
     <div class="g-panel">
       <div class="sec-head"><h3>${t('panels.spaceWatch','Space Watch')}</h3><span class="badge">${t('badges.orbital','CELESTRAK')}</span></div>
       ${D.space ? `
-        <div class="econ-row"><span class="elabel">New Objects (30d)</span><span class="eval" style="color:var(--accent2)">${D.space.totalNewObjects||0}</span></div>
-        <div class="econ-row"><span class="elabel">Military Sats</span><span class="eval">${D.space.militarySats||0}</span></div>
+        <div class="econ-row"><span class="elabel">${t('space.newLast30d','New Objects (30d)')}</span><span class="eval" style="color:var(--accent2)">${D.space.totalNewObjects||0}</span></div>
+        <div class="econ-row"><span class="elabel">${t('space.militarySats','Military Sats')}</span><span class="eval">${D.space.militarySats||0}</span></div>
         <div class="econ-row"><span class="elabel">Starlink</span><span class="eval">${D.space.constellations?.starlink||0}</span></div>
         <div class="econ-row"><span class="elabel">OneWeb</span><span class="eval">${D.space.constellations?.oneweb||0}</span></div>
         ${D.space.iss ? `<div class="econ-row"><span class="elabel">ISS</span><span class="eval" style="color:var(--accent)">ALT ${((D.space.iss.apogee+D.space.iss.perigee)/2).toFixed(0)} km</span></div>` : ''}
-        ${Object.entries(D.space.militaryByCountry||{}).sort((a,b)=>b[1]-a[1]).slice(0,4).map(([c,n])=>`<div class="econ-row"><span class="elabel" style="padding-left:8px">${c}</span><span class="eval" style="font-size:10px">${n} mil sats</span></div>`).join('')}
+        ${Object.entries(D.space.militaryByCountry||{}).sort((a,b)=>b[1]-a[1]).slice(0,4).map(([c,n])=>`<div class="econ-row"><span class="elabel" style="padding-left:8px">${c}</span><span class="eval" style="font-size:10px">${n} ${t('space.milSats','mil sats')}</span></div>`).join('')}
         ${(D.space.signals||[]).length ? `<div style="margin-top:6px;padding:6px 8px;border:1px solid rgba(68,204,255,0.2);background:rgba(68,204,255,0.04);font-family:var(--mono);font-size:9px;color:var(--accent2);line-height:1.5">${D.space.signals.slice(0,2).join('<br>')}</div>` : ''}
-      ` : '<div style="font-family:var(--mono);font-size:10px;color:var(--dim)">NO SPACE DATA</div>'}
+      ` : '<div style="font-family:var(--mono);font-size:10px;color:var(--dim)">'+t('space.noData','NO SPACE DATA')+'</div>'}
     </div>`;
 }
 
@@ -692,14 +579,14 @@ function initMap(){
     if(globe && typeof globe.pauseAnimation === 'function') globe.pauseAnimation();
     document.getElementById('globeViz').style.display = 'none';
     document.getElementById('flatMapSvg').style.display = 'block';
-    document.getElementById('projToggle').textContent = 'GLOBE MODE';
-    document.getElementById('mapHint').textContent = 'SCROLL TO ZOOM · DRAG TO PAN';
+    document.getElementById('projToggle').textContent = t('map.globeMode','GLOBE MODE');
+    document.getElementById('mapHint').textContent = t('map.scrollToZoom','SCROLL TO ZOOM · DRAG TO PAN');
     if(!flatSvg) initFlatMap();
     else { flatG.selectAll('*').remove(); drawFlatMap(); }
     setMapLoading(false);
     return;
   }
-  setMapLoading(true, 'Initializing 3D Globe');
+  setMapLoading(true, t('map.initializing','Initializing 3D Globe'));
   requestAnimationFrame(() => {
     try {
       initGlobe();
@@ -708,8 +595,8 @@ function initMap(){
       isFlat = true;
       document.getElementById('globeViz').style.display = 'none';
       document.getElementById('flatMapSvg').style.display = 'block';
-      document.getElementById('projToggle').textContent = 'GLOBE MODE';
-      document.getElementById('mapHint').textContent = '3D LOAD FAILED · FLAT MODE';
+      document.getElementById('projToggle').textContent = t('map.globeMode','GLOBE MODE');
+      document.getElementById('mapHint').textContent = t('map.loadFailed','3D LOAD FAILED · FLAT MODE');
       if(!flatSvg) initFlatMap();
       else { flatG.selectAll('*').remove(); drawFlatMap(); }
       setMapLoading(false);
@@ -722,8 +609,8 @@ function initGlobe(){
     if(typeof globe.resumeAnimation === 'function') globe.resumeAnimation();
     document.getElementById('globeViz').style.display = 'block';
     document.getElementById('flatMapSvg').style.display = 'none';
-    document.getElementById('projToggle').textContent = 'FLAT MODE';
-    document.getElementById('mapHint').textContent = 'DRAG TO ROTATE · SCROLL TO ZOOM';
+    document.getElementById('projToggle').textContent = t('map.flatMode','FLAT MODE');
+    document.getElementById('mapHint').textContent = t('map.dragToRotate','DRAG TO ROTATE · SCROLL TO ZOOM');
     return;
   }
   const container = document.getElementById('mapContainer');
@@ -827,8 +714,8 @@ function initGlobe(){
   } else {
     document.getElementById('globeViz').style.display = 'block';
     document.getElementById('flatMapSvg').style.display = 'none';
-    document.getElementById('projToggle').textContent = 'FLAT MODE';
-    document.getElementById('mapHint').textContent = 'DRAG TO ROTATE · SCROLL TO ZOOM';
+    document.getElementById('projToggle').textContent = t('map.flatMode','FLAT MODE');
+    document.getElementById('mapHint').textContent = t('map.dragToRotate','DRAG TO ROTATE · SCROLL TO ZOOM');
   }
 
   globeInitialized = true;
@@ -906,7 +793,7 @@ function plotMarkers(){
     points.push({
       lat:o.lat, lng:o.lon, size:0.3, alt:0.018,
       color:'rgba(255,184,76,0.8)', type:'osint', priority:2,
-      popHead:(post.channel||'').toUpperCase(), popMeta:`${post.views?.toLocaleString()||'?'} views`,
+      popHead:(post.channel||'').toUpperCase(), popMeta:`${post.views?.toLocaleString()||'?'} ${t('badges.views','views')}`,
       popText:cleanText(post.text?.substring(0,200)||'')
     });
   });
@@ -1131,8 +1018,8 @@ function toggleMapMode(){
   isFlat = !isFlat;
   const btn = document.getElementById('projToggle');
   const hint = document.getElementById('mapHint');
-  btn.textContent = isFlat ? 'GLOBE MODE' : 'FLAT MODE';
-  hint.textContent = isFlat ? 'SCROLL TO ZOOM · DRAG TO PAN' : 'DRAG TO ROTATE · SCROLL TO ZOOM';
+  btn.textContent = isFlat ? t('map.globeMode','GLOBE MODE') : t('map.flatMode','FLAT MODE');
+  hint.textContent = isFlat ? t('map.scrollToZoom','SCROLL TO ZOOM · DRAG TO PAN') : t('map.dragToRotate','DRAG TO ROTATE · SCROLL TO ZOOM');
   const globeEl = document.getElementById('globeViz');
   const flatEl = document.getElementById('flatMapSvg');
   if(isFlat){
@@ -1144,7 +1031,7 @@ function toggleMapMode(){
     else { flatG.selectAll('*').remove(); drawFlatMap(); }
   } else {
     flatEl.style.display = 'none';
-    setMapLoading(true, 'Initializing 3D Globe');
+    setMapLoading(true, t('map.initializing','Initializing 3D Globe'));
     requestAnimationFrame(() => {
       try {
         initGlobe();
@@ -1155,8 +1042,8 @@ function toggleMapMode(){
         isFlat = true;
         globeEl.style.display = 'none';
         flatEl.style.display = 'block';
-        btn.textContent = 'GLOBE MODE';
-        hint.textContent = '3D LOAD FAILED · FLAT MODE';
+        btn.textContent = t('map.globeMode','GLOBE MODE');
+        hint.textContent = t('map.loadFailed','3D LOAD FAILED · FLAT MODE');
         if(!flatSvg) initFlatMap();
         else { flatG.selectAll('*').remove(); drawFlatMap(); }
         setMapLoading(false);
@@ -1234,7 +1121,7 @@ function plotFlatMarkers(){
   D.sdr.zones.forEach(z=>z.receivers.forEach(r=>{addPt(r.lat,r.lon,2.5,'rgba(68,204,255,0.5)','rgba(68,204,255,0.2)',ev=>showPopup(ev,'SDR',`${r.name}<br>${z.region}`,'KiwiSDR'),3)}));
   // OSINT
   const osintGeo=[{lat:45,lon:41,idx:0},{lat:48,lon:37,idx:1},{lat:48.5,lon:37.5,idx:2},{lat:45,lon:40.2,idx:3},{lat:50.6,lon:36.6,idx:5},{lat:48.5,lon:35,idx:6}];
-  osintGeo.forEach(o=>{const p=D.tg.urgent[o.idx];if(!p)return;addPt(o.lat,o.lon,4,'rgba(255,184,76,0.7)','rgba(255,184,76,0.3)',ev=>showPopup(ev,(p.channel||'').toUpperCase(),cleanText(p.text?.substring(0,200)||''),`${p.views||'?'} views`),2)});
+  osintGeo.forEach(o=>{const p=D.tg.urgent[o.idx];if(!p)return;addPt(o.lat,o.lon,4,'rgba(255,184,76,0.7)','rgba(255,184,76,0.3)',ev=>showPopup(ev,(p.channel||'').toUpperCase(),cleanText(p.text?.substring(0,200)||''),`${p.views||'?'} ${t('badges.views','views')}`),2)});
   // WHO
   const whoGeo=[{lat:0.3,lon:32.6},{lat:-6.2,lon:106.8},{lat:-4.3,lon:15.3},{lat:35,lon:105},{lat:12.5,lon:105},{lat:35,lon:105},{lat:28,lon:84},{lat:24,lon:45},{lat:30,lon:70},{lat:-0.8,lon:11.6}];
   D.who.slice(0,10).forEach((w,i)=>{const c=whoGeo[i];if(!c)return;addPt(c.lat,c.lon,3.5,'rgba(105,240,174,0.6)','rgba(105,240,174,0.2)',ev=>showPopup(ev,w.title,w.summary||'','WHO'),2)});
@@ -1376,16 +1263,16 @@ function renderLower(){
   const dayMove = (pct) => pct != null ? `${pct>=0?'+':''}${pct}% today` : '';
 
   const metrics=[
-    {l:'WTI Crude',v:`$${D.energy.wti}`,s:'$/bbl',p:70},
-    {l:'Brent',v:`$${D.energy.brent}`,s:'$/bbl',p:75},
-    {l:'Nat Gas',v:`$${D.energy.natgas||'--'}`,s:'$/MMBtu',p:30},
+    {l:t('metrics.wtiCrude','WTI Crude'),v:`$${D.energy.wti}`,s:'$/bbl',p:70},
+    {l:t('metrics.brent','Brent'),v:`$${D.energy.brent}`,s:'$/bbl',p:75},
+    {l:t('metrics.natGas','Nat Gas'),v:`$${D.energy.natgas||'--'}`,s:'$/MMBtu',p:30},
     {l:'Gold',v:fmtMarketPrice(metals.gold),s:dayMove(metals.goldChangePct)||'COMEX proxy',p:58},
     {l:'Silver',v:fmtMarketPrice(metals.silver),s:dayMove(metals.silverChangePct)||'COMEX proxy',p:54},
-    {l:'VIX',v:vixVal?vixVal.toFixed(1):'--',s:vixChg||'volatility index',p:vixVal?Math.min(vixVal*2.5,100):30},
-    {l:'Fed Funds',v:ff?`${ff.value}%`:'--',s:ff?.date||'',p:36},
-    {l:'GSCPI',v:gscpi?gscpi.value.toFixed(2):'--',s:gscpi?.interpretation||'',p:49},
-    {l:'CPI MoM',v:cpi?`+${cpi.momChangePct?.toFixed(2)}%`:'--',s:cpi?.date||'',p:37},
-    {l:'Unemployment',v:ue?`${ue.value}%`:'--',s:ue?`${ue.momChange>0?'+':''}${ue.momChange} vs prior`:'',p:44},
+    {l:t('metrics.vix','VIX'),v:vixVal?vixVal.toFixed(1):'--',s:vixChg||'volatility index',p:vixVal?Math.min(vixVal*2.5,100):30},
+    {l:t('metrics.fedFunds','Fed Funds'),v:ff?`${ff.value}%`:'--',s:ff?.date||'',p:36},
+    {l:t('metrics.gscpi','GSCPI'),v:gscpi?gscpi.value.toFixed(2):'--',s:gscpi?.interpretation||'',p:49},
+    {l:t('metrics.cpiMom','CPI MoM'),v:cpi?`+${cpi.momChangePct?.toFixed(2)}%`:'--',s:cpi?.date||'',p:37},
+    {l:t('metrics.unemployment','Unemployment'),v:ue?`${ue.value}%`:'--',s:ue?`${ue.momChange>0?'+':''}${ue.momChange} ${t('metrics.vsPrior','vs prior')}`:'',p:44},
   ];
 
   // Attach sparklines from FRED recent data
@@ -1440,14 +1327,14 @@ function renderLower(){
       <span class="idea-type ${(idea.type||'').toLowerCase()}">${(idea.type||'').toUpperCase()}</span>
       ${idea.ticker ? `<span class="idea-horizon">${idea.ticker}</span>` : ''}
       ${idea.horizon ? `<span class="idea-horizon">${idea.horizon}</span>` : ''}
-      <span class="idea-conf">${idea.confidence} confidence</span>
+      <span class="idea-conf">${idea.confidence} ${t('ideas.confidence','Confidence')}</span>
       <div class="idea-title">${idea.title}</div>
       <div class="idea-text">${idea.text||idea.rationale||''}</div>
       ${idea.risk ? `<div class="idea-text" style="color:var(--warn);margin-top:3px">Risk: ${idea.risk}</div>` : ''}
     </div>`).join('') : `<div style="padding:20px;text-align:center;color:var(--dim);font-family:var(--mono);font-size:11px">
       <div style="font-size:24px;margin-bottom:8px;opacity:0.3">&#9888;</div>
-      <div>LLM NOT CONFIGURED</div>
-      <div style="font-size:9px;margin-top:6px;opacity:0.6">Set LLM_PROVIDER + credentials in .env to enable AI-powered trade ideas</div>
+      <div>${t('ideas.llmNotConfigured','LLM NOT CONFIGURED')}</div>
+      <div style="font-size:9px;margin-top:6px;opacity:0.6">${t('ideas.llmHelp','Set LLM_PROVIDER + credentials in .env to enable AI-powered trade ideas')}</div>
     </div>`;
 
 
@@ -1461,29 +1348,29 @@ function renderLower(){
   const macroPanel = `<div class="g-panel lp-macro">
       <div class="sec-head"><h3>${t('panels.macroMarkets','Macro + Markets')}</h3><span class="badge">${mkt.timestamp?t('badges.live','LIVE'):t('badges.delayed','DELAYED')}</span></div>
       ${hasMarkets?`<div style="margin-bottom:8px">
-        <div style="font-family:var(--mono);font-size:9px;color:var(--dim);margin-bottom:4px;letter-spacing:1px">INDEXES</div>
+        <div style="font-family:var(--mono);font-size:9px;color:var(--dim);margin-bottom:4px;letter-spacing:1px">${t('metrics.indexes','INDEXES')}</div>
         <div class="metrics-row">${indexCards}</div>
       </div>
       <div style="margin-bottom:8px">
-        <div style="font-family:var(--mono);font-size:9px;color:var(--dim);margin-bottom:4px;letter-spacing:1px">CRYPTO</div>
+        <div style="font-family:var(--mono);font-size:9px;color:var(--dim);margin-bottom:4px;letter-spacing:1px">${t('metrics.crypto','CRYPTO')}</div>
         <div class="metrics-row">${cryptoCards}</div>
       </div>`:''}
       <div style="margin-bottom:8px">
-        <div style="font-family:var(--mono);font-size:9px;color:var(--dim);margin-bottom:4px;letter-spacing:1px">ENERGY + METALS + MACRO</div>
+        <div style="font-family:var(--mono);font-size:9px;color:var(--dim);margin-bottom:4px;letter-spacing:1px">${t('metrics.energyMacro','ENERGY + METALS + MACRO')}</div>
         <div class="metrics-row">${metrics.map(m=>{
           const sparkSvg = m.spark ? mkSparkSvg(m.spark, m.sparkUp) : '';
           return `<div class="mc"><div class="ml">${m.l}</div><span class="mv">${m.v}${sparkSvg}</span><span class="ms">${m.s}</span><div class="mbar"><span style="width:${m.p}%"></span></div></div>`;
         }).join('')}</div>
       </div>
       <div style="margin-top:6px">
-        <div style="font-family:var(--mono);font-size:10px;color:var(--dim);margin-bottom:4px">WTI 5-DAY</div>
+        <div style="font-family:var(--mono);font-size:10px;color:var(--dim);margin-bottom:4px">${t('metrics.wti5day','WTI 5-DAY')}</div>
         <div class="spark">${sparkHtml}</div>
       </div>
     </div>`;
   const ideasPanel = `<div class="g-panel lp-ideas">
       <div class="sec-head"><h3>${t('panels.tradeIdeas','Leverageable Ideas')}</h3>${D.ideasSource==='llm'?'<span class="ideas-src llm">'+t('ideas.aiEnhanced','AI ENHANCED')+'</span>':D.ideasSource==='disabled'?'<span class="ideas-src static">'+t('ideas.llmOff','LLM OFF')+'</span>':'<span class="ideas-src static">'+t('ideas.pending','PENDING')+'</span>'}</div>
       ${ideasHtml}
-      <div class="disclosure">FOR INFORMATIONAL PURPOSES ONLY. This is not financial advice, a recommendation to buy or sell any security, or a solicitation of any kind. All signal-based observations are derived from publicly available OSINT data and should not be relied upon for investment decisions. Consult a licensed financial advisor before making any investment. Past performance does not guarantee future results.</div>
+      <div class="disclosure">${t('ideas.disclosure','FOR INFORMATIONAL PURPOSES ONLY. This is not financial advice, a recommendation to buy or sell any security, or a solicitation of any kind. All signal-based observations are derived from publicly available OSINT data and should not be relied upon for investment decisions. Consult a licensed financial advisor before making any investment. Past performance does not guarantee future results.')}</div>
     </div>`;
   document.getElementById('lowerGrid').innerHTML=`${tickerPanel}${osintPanel}${macroPanel}${ideasPanel}`;
 }
@@ -1496,12 +1383,12 @@ function renderRight(){
 
   // OSINT TICKER — Telegram + WHO as flowing cards
   const signalMetrics=[
-    {l:'Incident Tempo',v:D.tg.urgent.length,p:70},
-    {l:'Air Theaters',v:D.air.length,p:60},
-    {l:'Thermal Spikes',v:D.thermal.reduce((s,t)=>s+t.hc,0),p:80},
-    {l:'SDR Nodes',v:D.sdr.total,p:92},
-    {l:'Chokepoints',v:D.chokepoints.length,p:50},
-    {l:'WHO Alerts',v:D.who.length,p:40}
+    {l:t('signalMetrics.incidentTempo','Incident Tempo'),v:D.tg.urgent.length,p:70},
+    {l:t('signalMetrics.airTheaters','Air Theaters'),v:D.air.length,p:60},
+    {l:t('signalMetrics.thermalSpikes','Thermal Spikes'),v:D.thermal.reduce((s,t)=>s+t.hc,0),p:80},
+    {l:t('signalMetrics.sdrNodes','SDR Nodes'),v:D.sdr.total,p:92},
+    {l:t('signalMetrics.chokepoints','Chokepoints'),v:D.chokepoints.length,p:50},
+    {l:t('signalMetrics.whoAlerts','WHO Alerts'),v:D.who.length,p:40}
   ];
 
   // DELTA PANEL — what changed since last sweep
@@ -1550,13 +1437,13 @@ function renderRight(){
 }
 
 // === HELPERS ===
-function getAge(d){const ms=Date.now()-new Date(d).getTime();const h=Math.floor(ms/3600000);if(h<1)return 'just now';if(h<24)return h+'h ago';return Math.floor(h/24)+'d ago'}
+function getAge(d){const ms=Date.now()-new Date(d).getTime();const h=Math.floor(ms/3600000);if(h<1)return t('time.justNow','just now');if(h<24)return t('time.hoursAgo','{hours}h ago').replace('{hours}',h);return t('time.daysAgo','{days}d ago').replace('{days}',Math.floor(h/24))}
 function cleanText(t){return t.replace(/&#39;/g,"'").replace(/&#33;/g,"!").replace(/&amp;/g,"&").replace(/<[^>]+>/g,'')}
 function safeExternalUrl(raw){try{const u=new URL(raw,location.href);return u.protocol==='http:'||u.protocol==='https:'?u.toString():null}catch{return null}}
 
 // === BOOT SEQUENCE ===
 function runBoot(){
-  const acledStatus = D.acled?.totalEvents > 0 ? `<span class="ok">${D.acled.totalEvents} EVENTS</span>` : '<span style="color:var(--warn)">DEGRADED</span>';
+  const acledStatus = D.acled?.totalEvents > 0 ? `<span class="ok">${D.acled.totalEvents} ${t('boot.events','EVENTS')}</span>` : '<span style="color:var(--warn)">'+t('boot.degraded','DEGRADED')+'</span>';
   const lines=[
     {text:t('boot.initializing','INITIALIZING CRUCIX ENGINE v2.1.0'),delay:0},
     {text:t('boot.connecting','CONNECTING {count} OSINT SOURCES...').replace('{count}',D.meta.sourcesQueried),delay:400},
@@ -1626,16 +1513,17 @@ function buildOsintPanel(panelClass='', maxHeight=260){
 function renderGlossary(){
   const body = document.getElementById('glossaryBody');
   if(!body) return;
-  body.innerHTML = signalGuideItems.map(item => `
+  const items = signalGuideItems.length ? signalGuideItems : [];
+  body.innerHTML = items.map(item => `
     <div class="glossary-card">
       <div class="glossary-term">
         <strong>${item.term}</strong>
         <span class="glossary-tag">${item.category}</span>
       </div>
-      <div class="glossary-line"><span class="glossary-label">Meaning</span>${item.meaning}</div>
-      <div class="glossary-line"><span class="glossary-label">Why it matters</span>${item.matters}</div>
-      <div class="glossary-line"><span class="glossary-label">Not proof of</span>${item.notMeaning}</div>
-      <div class="glossary-line"><span class="glossary-label">Example</span>${item.example}</div>
+      <div class="glossary-line"><span class="glossary-label">${t('glossary.labelMeaning','Meaning')}</span>${item.meaning}</div>
+      <div class="glossary-line"><span class="glossary-label">${t('glossary.labelMatters','Why it matters')}</span>${item.matters}</div>
+      <div class="glossary-line"><span class="glossary-label">${t('glossary.labelNotProof','Not proof of')}</span>${item.notMeaning}</div>
+      <div class="glossary-line"><span class="glossary-label">${t('glossary.labelExample','Example')}</span>${item.example}</div>
     </div>
   `).join('');
 }

--- a/dashboard/public/loading.html
+++ b/dashboard/public/loading.html
@@ -47,7 +47,7 @@ html,body{height:100%;background:var(--bg);color:var(--text);font-family:var(--m
 
   <div id="status">
     <span class="blink"></span>
-    <span id="statusText">COLLECTING DATA...</span>
+    <span id="statusText"></span>
   </div>
 
   <div id="countdown">
@@ -57,16 +57,30 @@ html,body{height:100%;background:var(--bg);color:var(--text);font-family:var(--m
 </div>
 
 <script>
-const SWEEP_ESTIMATE_S = 50; // estimated sweep duration in seconds
+const L = window.__CRUCIX_LOCALE__ || {};
+function t(keyPath, fallback) {
+  const keys = keyPath.split('.');
+  let value = L;
+  for (const key of keys) {
+    if (value && typeof value === 'object' && key in value) {
+      value = value[key];
+    } else {
+      return fallback || keyPath;
+    }
+  }
+  return typeof value === 'string' ? value : (fallback || keyPath);
+}
+
+const SWEEP_ESTIMATE_S = 50;
 
 const lines = [
-  'CRUCIX INTELLIGENCE ENGINE v2.0.0',
-  'INITIATING FIRST SWEEP...',
-  '├── CONNECTING 25 OSINT SOURCES',
-  '├── GDELT · OPENSKY · FIRMS · MARITIME · SAFECAST',
-  '├── FRED · BLS · EIA · TREASURY · GSCPI',
-  '└── TELEGRAM · WHO · OFAC · ACLED · REDDIT · BLUESKY',
-  '<span class="ok">AWAITING SWEEP COMPLETION...</span>',
+  t('loading.engine', 'CRUCIX INTELLIGENCE ENGINE v2.0.0'),
+  t('loading.initiating', 'INITIATING FIRST SWEEP...'),
+  t('loading.connecting', 'CONNECTING 25 OSINT SOURCES'),
+  t('loading.sources1', 'GDELT · OPENSKY · FIRMS · MARITIME · SAFECAST'),
+  t('loading.sources2', 'FRED · BLS · EIA · TREASURY · GSCPI'),
+  t('loading.sources3', 'TELEGRAM · WHO · OFAC · ACLED · REDDIT · BLUESKY'),
+  '<span class="ok">' + t('loading.awaitingSweep', 'AWAITING SWEEP COMPLETION...') + '</span>',
 ];
 
 const container = document.getElementById('bootLines');
@@ -80,11 +94,11 @@ lines.forEach((text, i) => {
 });
 
 const statusMessages = [
-  'COLLECTING DATA...',
-  'PROCESSING SOURCES...',
-  'SYNTHESIZING SIGNALS...',
-  'CORRELATING FEEDS...',
-  'AWAITING COMPLETION...',
+  t('loading.statusCollecting', 'COLLECTING DATA...'),
+  t('loading.statusProcessing', 'PROCESSING SOURCES...'),
+  t('loading.statusSynthesizing', 'SYNTHESIZING SIGNALS...'),
+  t('loading.statusCorrelating', 'CORRELATING FEEDS...'),
+  t('loading.statusAwaiting', 'AWAITING COMPLETION...'),
 ];
 let statusIdx = 0;
 const statusText = document.getElementById('statusText');
@@ -92,6 +106,7 @@ setInterval(() => {
   statusIdx = (statusIdx + 1) % statusMessages.length;
   statusText.textContent = statusMessages[statusIdx];
 }, 4000);
+statusText.textContent = statusMessages[0];
 
 // === Countdown ===
 const etaText = document.getElementById('etaText');
@@ -103,13 +118,13 @@ function startCountdown(elapsedSeconds) {
 
   function tick() {
     if (remaining <= 0) {
-      etaText.textContent = 'FINALIZING...';
+      etaText.textContent = t('loading.statusFinalizing', 'FINALIZING...');
       barFill.style.width = '99%';
       return;
     }
     const pct = Math.min(99, ((SWEEP_ESTIMATE_S - remaining) / SWEEP_ESTIMATE_S) * 100);
     barFill.style.width = pct + '%';
-    etaText.innerHTML = `EST. READY IN <span class="eta">~${remaining}s</span>`;
+    etaText.innerHTML = t('loading.eta', 'EST. READY IN ~{remaining}s').replace('{remaining}', remaining);
     remaining--;
   }
 
@@ -139,7 +154,7 @@ function goToDashboard() {
   barFill.style.transition = 'width 0.4s ease';
   barFill.style.width = '100%';
   etaText.textContent = '';
-  statusText.textContent = 'TERMINAL READY — LOADING DASHBOARD';
+  statusText.textContent = t('loading.statusReady', 'TERMINAL READY — LOADING DASHBOARD');
   setTimeout(() => location.replace('/'), 800);
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   crucix:
-    build: .
+    build:
+      context: .
+      network: host
+    network_mode: host
     ports:
       - "${PORT:-3117}:${PORT:-3117}"
     env_file:

--- a/lib/alerts/telegram.mjs
+++ b/lib/alerts/telegram.mjs
@@ -616,6 +616,9 @@ export class TelegramAlerter {
   // ─── Prompt Engineering ─────────────────────────────────────────────────
 
   _buildEvaluationPrompt() {
+    const langSuffix = (process.env.CRUCIX_LANG || '').toLowerCase().startsWith('zh')
+      ? '\n\n重要提示：所有输出必须使用中文（简体）。保持专业、准确的术语表达。'
+      : '';
     return `You are Crucix, an elite intelligence alert evaluator for a personal OSINT monitoring system. You analyze signal deltas from a 25-source intelligence sweep and decide if the user needs to be alerted via Telegram.
 
 ## Your Decision Framework
@@ -660,7 +663,7 @@ Respond with ONLY valid JSON:
   "signals": ["signal1", "signal2"],
   "confidence": "HIGH" | "MEDIUM" | "LOW",
   "crossCorrelation": "Which domains are confirming each other (e.g. 'conflict + energy + satellite')"
-}`;
+}${langSuffix}`;
   }
 
   _buildSignalContext(signals, delta) {

--- a/lib/i18n.mjs
+++ b/lib/i18n.mjs
@@ -10,7 +10,7 @@ const __dirname = dirname(__filename);
 const LOCALES_DIR = join(__dirname, '..', 'locales');
 
 // Supported languages
-const SUPPORTED_LOCALES = ['en', 'fr'];
+const SUPPORTED_LOCALES = ['en', 'fr', 'zh'];
 const DEFAULT_LOCALE = 'en';
 
 // Cache loaded locales
@@ -102,9 +102,13 @@ export function t(keyPath, params = {}) {
  */
 export function getLLMPrompt() {
   const locale = getLocale();
-  // Use loadLocale('en') for fallback since getLocale() doesn't accept a language argument
   const fallbackLocale = loadLocale('en');
-  return locale.llm?.systemPrompt || fallbackLocale.llm?.systemPrompt || '';
+  const prompt = locale.llm?.systemPrompt || fallbackLocale.llm?.systemPrompt || '';
+  const lang = getLanguage();
+  if (lang === 'zh' && prompt) {
+    return prompt + '\n\n重要提示：所有输出必须使用中文（简体）。保持专业、准确的术语表达。';
+  }
+  return prompt;
 }
 
 /**

--- a/lib/llm/deepseek.mjs
+++ b/lib/llm/deepseek.mjs
@@ -1,0 +1,55 @@
+// DeepSeek Provider — raw fetch, no SDK
+// API compatible with OpenAI format
+
+import { LLMProvider } from './provider.mjs';
+
+export class DeepSeekProvider extends LLMProvider {
+  constructor(config) {
+    super(config);
+    this.name = 'deepseek';
+    this.apiKey = config.apiKey;
+    this.model = config.model || 'deepseek-chat';
+  }
+
+  get isConfigured() {
+    return !!this.apiKey;
+  }
+
+  async complete(systemPrompt, userMessage, opts = {}) {
+    const res = await fetch('https://api.deepseek.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.model,
+        max_tokens: opts.maxTokens || 4096,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userMessage },
+        ],
+        stream: false,
+        temperature: 0,
+      }),
+      signal: AbortSignal.timeout(opts.timeout || 60000),
+    });
+
+    if (!res.ok) {
+      const err = await res.text().catch(() => '');
+      throw new Error(`DeepSeek API ${res.status}: ${err.substring(0, 200)}`);
+    }
+
+    const data = await res.json();
+    const text = data.choices?.[0]?.message?.content || '';
+
+    return {
+      text,
+      usage: {
+        inputTokens: data.usage?.prompt_tokens || 0,
+        outputTokens: data.usage?.completion_tokens || 0,
+      },
+      model: data.model || this.model,
+    };
+  }
+}

--- a/lib/llm/ideas.mjs
+++ b/lib/llm/ideas.mjs
@@ -1,5 +1,7 @@
 // LLM-Powered Trade Ideas — generates actionable ideas from sweep data + delta context
 
+import { getLLMPrompt } from '../i18n.mjs';
+
 /**
  * Generate LLM-enhanced trade ideas from sweep data.
  * @param {LLMProvider} provider - configured LLM provider
@@ -19,7 +21,7 @@ export async function generateLLMIdeas(provider, sweepData, delta, previousIdeas
     return null;
   }
 
-  const systemPrompt = `You are a quantitative analyst at a macro intelligence firm. You receive structured OSINT + economic data from 25 sources and produce 5-8 actionable trade ideas.
+  const systemPrompt = getLLMPrompt() || `You are a quantitative analyst at a macro intelligence firm. You receive structured OSINT + economic data from 25 sources and produce 5-8 actionable trade ideas.
 
 Rules:
 - Each idea must cite specific data points from the input

--- a/lib/llm/index.mjs
+++ b/lib/llm/index.mjs
@@ -9,6 +9,7 @@ import { MiniMaxProvider } from "./minimax.mjs";
 import { MistralProvider } from "./mistral.mjs";
 import { OllamaProvider } from "./ollama.mjs";
 import { GrokProvider } from "./grok.mjs";
+import { DeepSeekProvider } from "./deepseek.mjs";
 
 export { LLMProvider } from "./provider.mjs";
 export { AnthropicProvider } from "./anthropic.mjs";
@@ -20,6 +21,7 @@ export { MiniMaxProvider } from "./minimax.mjs";
 export { MistralProvider } from "./mistral.mjs";
 export { OllamaProvider } from "./ollama.mjs";
 export { GrokProvider } from "./grok.mjs";
+export { DeepSeekProvider } from "./deepseek.mjs";
 
 /**
  * Create an LLM provider based on config.
@@ -50,6 +52,8 @@ export function createLLMProvider(llmConfig) {
       return new OllamaProvider({ model, baseUrl: llmConfig.baseUrl });
     case 'grok':
       return new GrokProvider({ apiKey, model });
+    case 'deepseek':
+      return new DeepSeekProvider({ apiKey, model });
     default:
       console.warn(
         `[LLM] Unknown provider "${provider}". LLM features disabled.`,

--- a/lib/llm/translate.mjs
+++ b/lib/llm/translate.mjs
@@ -1,0 +1,163 @@
+// LLM-Powered Translation — batch translates news headlines and OSINT text
+
+const CHINESE_REGEX = /[\u4e00-\u9fff]/;
+
+function hasChinese(text) {
+  return CHINESE_REGEX.test(text);
+}
+
+function stripNumberPrefix(text) {
+  return text.replace(/^\d+\.\s*/, '');
+}
+
+/**
+ * Batch translate news feed headlines using LLM.
+ * Groups headlines into batches of 20 to keep token usage reasonable.
+ * @param {LLMProvider} provider - configured LLM provider
+ * @param {Array} feed - newsFeed array with headline fields
+ * @param {string} targetLang - target language code (default: 'zh')
+ * @returns {Promise<Array>} - feed with translated headlines
+ */
+export async function translateNewsFeed(provider, feed, targetLang = 'zh') {
+  if (!provider?.isConfigured) return feed;
+  if (targetLang !== 'zh') return feed;
+
+  // Filter items that actually need translation
+  const itemsToTranslate = feed.filter(item => item.headline && !hasChinese(item.headline));
+  if (itemsToTranslate.length === 0) return feed;
+
+  const BATCH_SIZE = 20;
+  const translated = new Map();
+
+  for (let i = 0; i < itemsToTranslate.length; i += BATCH_SIZE) {
+    const batch = itemsToTranslate.slice(i, i + BATCH_SIZE);
+    const result = await translateBatch(provider, batch.map(b => b.headline), targetLang, 'news');
+    if (result && Array.isArray(result)) {
+      batch.forEach((item, idx) => {
+        if (result[idx] && typeof result[idx] === 'string') {
+          translated.set(item, stripNumberPrefix(result[idx].trim()));
+        }
+      });
+    }
+  }
+
+  if (translated.size === 0) return feed;
+
+  return feed.map(item => {
+    if (translated.has(item)) {
+      return { ...item, headline: translated.get(item), _translated: true };
+    }
+    return item;
+  });
+}
+
+/**
+ * Batch translate Telegram OSINT posts.
+ * Translates the `text` field of each post object.
+ * @param {LLMProvider} provider - configured LLM provider
+ * @param {Array} posts - array of { text, channel, views, date, ... }
+ * @param {string} targetLang - target language code (default: 'zh')
+ * @returns {Promise<Array>} - posts with translated text
+ */
+export async function translateTelegramPosts(provider, posts, targetLang = 'zh') {
+  if (!provider?.isConfigured) return posts;
+  if (targetLang !== 'zh') return posts;
+
+  // Filter items that actually need translation
+  const itemsToTranslate = posts.filter(p => p.text && !hasChinese(p.text));
+  if (itemsToTranslate.length === 0) return posts;
+
+  const BATCH_SIZE = 15;
+  const translated = new Map();
+
+  for (let i = 0; i < itemsToTranslate.length; i += BATCH_SIZE) {
+    const batch = itemsToTranslate.slice(i, i + BATCH_SIZE);
+    const result = await translateBatch(provider, batch.map(b => b.text), targetLang, 'telegram');
+    if (result && Array.isArray(result)) {
+      batch.forEach((item, idx) => {
+        if (result[idx] && typeof result[idx] === 'string') {
+          translated.set(item, stripNumberPrefix(result[idx].trim()));
+        }
+      });
+    }
+  }
+
+  if (translated.size === 0) return posts;
+
+  return posts.map(item => {
+    if (translated.has(item)) {
+      return { ...item, text: translated.get(item), _translated: true };
+    }
+    return item;
+  });
+}
+
+/**
+ * Translate a batch of text strings.
+ * @param {LLMProvider} provider
+ * @param {string[]} texts
+ * @param {string} targetLang
+ * @param {string} context - 'news' | 'telegram'
+ * @returns {Promise<string[]|null>}
+ */
+async function translateBatch(provider, texts, targetLang, context = 'news') {
+  const isZh = targetLang === 'zh';
+
+  let systemPrompt;
+  if (isZh) {
+    if (context === 'telegram') {
+      systemPrompt = `你是一位专业的情报分析师和翻译。请将以下 OSINT（开源情报）社交媒体帖子翻译成自然、地道的中文（简体）。\n\n翻译要求：\n- 保持原文的语气、紧迫感和信息密度\n- 保留专有名词（人名、地名、机构名）的可识别性\n- 保留 URL、@提及、hashtag 等标记的原始形式\n- 不添加解释、编号或 markdown 代码块\n- 只输出有效的 JSON 数组，每个元素按顺序对应输入文本`;
+    } else {
+      systemPrompt = `你是一位专业的新闻翻译。请将以下新闻标题翻译成自然、流畅的中文（简体）。保持原意和语气，使用准确的专业术语。\n\n必须遵守：\n- 只输出有效的 JSON 数组\n- 数组中每个元素按顺序对应输入的标题\n- 不要添加解释、编号或 markdown 代码块`;
+    }
+  } else {
+    systemPrompt = `You are a professional translator. Translate the following texts into natural, fluent ${targetLang}. Preserve meaning and tone.\n\nRules:\n- Output ONLY a valid JSON array\n- Each element corresponds to the input text in order\n- No explanations, numbering, or markdown code blocks`;
+  }
+
+  const userMessage = texts.map((t, i) => `${i + 1}. ${t}`).join('\n');
+
+  try {
+    const result = await provider.complete(systemPrompt, userMessage, {
+      maxTokens: Math.min(4096, texts.length * 120),
+      timeout: 30000,
+    });
+
+    const parsed = parseJSONArray(result.text);
+    if (!parsed) {
+      console.warn(`[Translate] Failed to parse JSON for ${context} batch of ${texts.length} items.`);
+    } else if (parsed.length !== texts.length) {
+      console.warn(`[Translate] Mismatch: expected ${texts.length} items, got ${parsed.length} for ${context}`);
+    }
+    return parsed;
+  } catch (err) {
+    console.warn('[Translate] Batch failed:', err.message);
+    return null;
+  }
+}
+
+/**
+ * Parse JSON array from LLM response. Handles markdown code blocks.
+ */
+function parseJSONArray(text) {
+  if (!text) return null;
+  let cleaned = text.trim();
+
+  // Strip markdown code block wrappers
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\n?/i, '').replace(/\n?```$/, '');
+  }
+
+  try {
+    const parsed = JSON.parse(cleaned);
+    if (Array.isArray(parsed)) return parsed;
+  } catch {
+    // Try to extract array from mixed text
+    const match = cleaned.match(/\[[\s\S]*\]/);
+    if (match) {
+      try {
+        return JSON.parse(match[0]);
+      } catch { /* give up */ }
+    }
+  }
+  return null;
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -108,7 +108,10 @@
     "weatherAlert": "Weather Alert",
     "epaRadNet": "EPA RadNet",
     "spaceStation": "Space Station",
-    "gdeltEvent": "GDELT Event"
+    "gdeltEvent": "GDELT Event",
+    "initializing": "Initializing 3D Globe",
+    "loadFailed": "3D LOAD FAILED · FLAT MODE",
+    "dragToRotate": "DRAG TO ROTATE · SCROLL TO ZOOM"
   },
   "ideas": {
     "confidence": "Confidence",
@@ -142,7 +145,8 @@
     "stress": "STRESS",
     "sweeping": "SWEEPING...",
     "europe": "EUROPE",
-    "orbital": "ORBITAL"
+    "orbital": "ORBITAL",
+    "views": "views"
   },
   "delta": {
     "baseline": "BASELINE",
@@ -221,7 +225,10 @@
     "totalTracked": "Total Tracked",
     "byCountry": "BY COUNTRY",
     "constellations": "CONSTELLATIONS",
-    "launches": "launches"
+    "launches": "launches",
+    "militarySats": "Military Sats",
+    "milSats": "mil sats",
+    "noData": "NO SPACE DATA"
   },
   "europe": {
     "noAlerts": "NO ACTIVE ALERTS",
@@ -355,5 +362,155 @@
     "errors": {
       "noDataYet": "No data yet — first sweep in progress"
     }
+  },
+  "glossary": {
+    "kicker": "Signal Guide",
+    "title": "What the signals actually mean",
+    "subtitle": "Plain-English interpretation, why it matters, and what you should not infer from it.",
+    "foot": "Treat these as interpretation guides, not conclusions. Stronger judgments should come from corroboration across multiple layers, not from a single signal viewed in isolation.",
+    "labelMeaning": "Meaning",
+    "labelMatters": "Why it matters",
+    "labelNotProof": "Not proof of",
+    "labelExample": "Example",
+    "categoryAir": "Air",
+    "categoryThermal": "Thermal",
+    "categoryMaritime": "Maritime",
+    "categorySignals": "Signals",
+    "categoryRadiation": "Radiation",
+    "categoryMacro": "Macro",
+    "categoryHealth": "Health",
+    "categoryPlatform": "Platform",
+    "items": [
+      {
+        "term": "No Callsign",
+        "category": "Air",
+        "meaning": "OpenSky received an aircraft track without a usable callsign or flight ID in that record.",
+        "matters": "Useful as an opacity signal. A cluster of missing callsigns can indicate incomplete transponder metadata or less transparent traffic.",
+        "notMeaning": "Not proof of military, covert, or hostile activity on its own.",
+        "example": "South China Sea: No Callsign 6 of 152 means 6 tracks in that theater had no usable callsign in the feed."
+      },
+      {
+        "term": "High Altitude",
+        "category": "Air",
+        "meaning": "Aircraft above 12,000 meters, roughly 39,000 feet, in the current OpenSky snapshot.",
+        "matters": "Separates cruise-level traffic from lower-altitude local or regional movement.",
+        "notMeaning": "Not a danger score and not inherently unusual. Commercial jets commonly operate here.",
+        "example": "High Altitude 2 means only 2 tracked aircraft in that hotspot were above the cruise threshold at that snapshot."
+      },
+      {
+        "term": "Top Countries",
+        "category": "Air",
+        "meaning": "The most common OpenSky origin_country values among aircraft in that hotspot.",
+        "matters": "Useful for understanding the rough composition of traffic flowing through a theater.",
+        "notMeaning": "Not who is controlling the aircraft right now and not a direct indicator of military ownership.",
+        "example": "China (61), Philippines (39), Taiwan (17) means those were the top registered origin countries in the snapshot."
+      },
+      {
+        "term": "FRP",
+        "category": "Thermal",
+        "meaning": "Fire Radiative Power. This is the intensity of one specific FIRMS hotspot, measured in megawatts.",
+        "matters": "Higher FRP usually means a hotter, larger, or more energetic fire event at that exact point.",
+        "notMeaning": "Not the intensity of the whole region and not automatic proof of conflict activity.",
+        "example": "Sudan / Horn of Africa: FRP 92.3 MW describes that one hotspot, while Total 1,451 describes the entire regional detection count."
+      },
+      {
+        "term": "Total Detections",
+        "category": "Thermal",
+        "meaning": "The total number of FIRMS thermal detections in the entire region bucket for the current sweep.",
+        "matters": "Useful for spotting unusually active fire clusters, especially when compared with historical baselines or night activity.",
+        "notMeaning": "Not a count for the single map point you clicked and not necessarily a conflict count.",
+        "example": "Total 1,451 means the whole Sudan / Horn of Africa bucket had 1,451 detections in that sweep."
+      },
+      {
+        "term": "Night Detections",
+        "category": "Thermal",
+        "meaning": "Thermal detections tagged as occurring at night inside the broader FIRMS region bucket.",
+        "matters": "Nighttime heat can be more noteworthy because it is less likely to be routine daytime land burning.",
+        "notMeaning": "Not a direct combat indicator. It still needs context from location, baseline, and corroborating sources.",
+        "example": "Night 140 means 140 of the 1,451 regional detections were nighttime detections in that sweep."
+      },
+      {
+        "term": "Chokepoint",
+        "category": "Maritime",
+        "meaning": "A strategic maritime corridor or passage where trade and energy flows can be delayed, diverted, or disrupted.",
+        "matters": "These nodes matter because a disruption here can affect shipping costs, transit times, and commodity pricing globally.",
+        "notMeaning": "Not proof that disruption is happening now. It is a strategic watch location.",
+        "example": "Bab el-Mandeb or the Strait of Hormuz matter because shipping and energy flows concentrate there."
+      },
+      {
+        "term": "SDR Receiver",
+        "category": "Signals",
+        "meaning": "A publicly reachable software-defined radio receiver in or near a region of interest.",
+        "matters": "Dense receiver coverage can give you more ability to monitor communications or signal activity in a theater.",
+        "notMeaning": "Not evidence of hostile emissions or a threat by itself. It is an observation and monitoring layer.",
+        "example": "South China Sea SDR count means publicly accessible KiwiSDR receivers are available in or near that zone."
+      },
+      {
+        "term": "CPM",
+        "category": "Radiation",
+        "meaning": "Counts per minute from a radiation monitoring source, used here for relative radiation status at a site.",
+        "matters": "Useful for spotting anomalies against the site's normal range or comparing consecutive readings.",
+        "notMeaning": "Not a direct safety verdict on its own. Interpretation depends on local baseline and trend, not the raw number alone.",
+        "example": "A site reading 33 CPM can be normal if that location's usual background level is in the same range."
+      },
+      {
+        "term": "HY Spread",
+        "category": "Macro",
+        "meaning": "High-yield credit spread, shown here as a stress proxy from FRED credit data.",
+        "matters": "When spreads widen, markets are usually pricing more credit stress and tighter financial conditions.",
+        "notMeaning": "Not a recession call by itself. It is one stress signal among many.",
+        "example": "A rising HY Spread alongside higher VIX and weaker equities is a stronger risk-off pattern than HY alone."
+      },
+      {
+        "term": "VIX",
+        "category": "Macro",
+        "meaning": "The CBOE Volatility Index, commonly used as a market-implied fear or volatility gauge.",
+        "matters": "Higher VIX often means more expected equity volatility and more defensive market positioning.",
+        "notMeaning": "Not a direct forecast of a crash and not a geopolitical indicator by itself.",
+        "example": "VIX above 20 with widening HY spreads is a stronger stress pattern than VIX alone."
+      },
+      {
+        "term": "GSCPI",
+        "category": "Macro",
+        "meaning": "The Global Supply Chain Pressure Index, a broad indicator of global supply-chain strain.",
+        "matters": "It helps translate geopolitical or weather disruptions into likely pressure on shipping, inventory, and pricing.",
+        "notMeaning": "Not a live market price and not a company-specific supply-chain score by itself.",
+        "example": "A higher GSCPI makes route or energy shocks more likely to spill into broader cost pressure."
+      },
+      {
+        "term": "WHO Alert",
+        "category": "Health",
+        "meaning": "A WHO Disease Outbreak News item or outbreak-related bulletin surfaced in the health layer.",
+        "matters": "Useful for watching outbreaks that could affect travel, supply chains, humanitarian stress, or regional operating conditions.",
+        "notMeaning": "Not a pandemic declaration and not automatically high severity.",
+        "example": "A WHO alert in a port-heavy region matters more if it overlaps shipping, border controls, or local instability signals."
+      },
+      {
+        "term": "Sweep Delta",
+        "category": "Platform",
+        "meaning": "The change summary between the current sweep and the previous one, including new, escalated, and de-escalated signals.",
+        "matters": "Useful for spotting what changed recently instead of re-reading the full dashboard from scratch.",
+        "notMeaning": "Not a full risk model. It is a directional change layer on top of the raw signals.",
+        "example": "A delta marked risk-off with several new and escalated items means the latest sweep materially worsened the signal mix."
+      }
+    ]
+  },
+  "loading": {
+    "title": "CRUCIX — Initializing",
+    "statusCollecting": "COLLECTING DATA...",
+    "statusProcessing": "PROCESSING SOURCES...",
+    "statusSynthesizing": "SYNTHESIZING SIGNALS...",
+    "statusCorrelating": "CORRELATING FEEDS...",
+    "statusAwaiting": "AWAITING COMPLETION...",
+    "statusFinalizing": "FINALIZING...",
+    "statusReady": "TERMINAL READY — LOADING DASHBOARD",
+    "eta": "EST. READY IN ~{remaining}s",
+    "awaitingSweep": "AWAITING SWEEP COMPLETION...",
+    "engine": "CRUCIX INTELLIGENCE ENGINE v2.0.0",
+    "initiating": "INITIATING FIRST SWEEP...",
+    "connecting": "CONNECTING 25 OSINT SOURCES",
+    "sources1": "GDELT · OPENSKY · FIRMS · MARITIME · SAFECAST",
+    "sources2": "FRED · BLS · EIA · TREASURY · GSCPI",
+    "sources3": "TELEGRAM · WHO · OFAC · ACLED · REDDIT · BLUESKY"
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -108,7 +108,10 @@
     "weatherAlert": "Alerte Météo",
     "epaRadNet": "EPA RadNet",
     "spaceStation": "Station Spatiale",
-    "gdeltEvent": "Événement GDELT"
+    "gdeltEvent": "Événement GDELT",
+    "initializing": "Initialisation du globe 3D",
+    "loadFailed": "ÉCHEC 3D · MODE PLAT",
+    "dragToRotate": "GLISSER POUR TOURNER · MOLETTE POUR ZOOMER"
   },
   "ideas": {
     "confidence": "Confiance",
@@ -142,7 +145,8 @@
     "stress": "STRESS",
     "sweeping": "SCAN EN COURS...",
     "europe": "EUROPE",
-    "orbital": "ORBITAL"
+    "orbital": "ORBITAL",
+    "views": "vues"
   },
   "delta": {
     "baseline": "RÉFÉRENCE",
@@ -221,7 +225,10 @@
     "totalTracked": "Total Suivi",
     "byCountry": "PAR PAYS",
     "constellations": "CONSTELLATIONS",
-    "launches": "lancements"
+    "launches": "lancements",
+    "militarySats": "Sats Militaires",
+    "milSats": "sats milit.",
+    "noData": "PAS DE DONNÉES SPATIALES"
   },
   "europe": {
     "noAlerts": "PAS D'ALERTES ACTIVES",
@@ -355,5 +362,155 @@
     "errors": {
       "noDataYet": "Pas encore de données — premier scan en cours"
     }
+  },
+  "glossary": {
+    "kicker": "Guide des Signaux",
+    "title": "Ce que les signaux signifient réellement",
+    "subtitle": "Interprétation simple, pourquoi c'est important et ce qu'il ne faut pas en déduire.",
+    "foot": "Traitez-les comme des guides d'interprétation, pas des conclusions. Des jugements plus solides devraient venir de la corroboration entre plusieurs couches, pas d'un seul signal isolé.",
+    "labelMeaning": "Signification",
+    "labelMatters": "Pourquoi c'est important",
+    "labelNotProof": "Ce que ce n'est pas",
+    "labelExample": "Exemple",
+    "categoryAir": "Aérien",
+    "categoryThermal": "Thermique",
+    "categoryMaritime": "Maritime",
+    "categorySignals": "Signaux",
+    "categoryRadiation": "Radiation",
+    "categoryMacro": "Macro",
+    "categoryHealth": "Santé",
+    "categoryPlatform": "Plateforme",
+    "items": [
+      {
+        "term": "Pas d'indicatif",
+        "category": "Aérien",
+        "meaning": "OpenSky a reçu une trace d'avion sans indicatif ou identifiant de vol utilisable dans cet enregistrement.",
+        "matters": "Utile comme signal d'opacité. Un cluster d'indicatifs manquants peut indiquer des métadonnées de transpondeur incomplètes ou un trafic moins transparent.",
+        "notMeaning": "Pas une preuve d'activité militaire, secrète ou hostile à elle seule.",
+        "example": "Mer de Chine méridionale : Pas d'indicatif 6 sur 152 signifie que 6 traces dans ce théâtre n'avaient pas d'indicatif utilisable dans le flux."
+      },
+      {
+        "term": "Haute altitude",
+        "category": "Aérien",
+        "meaning": "Avions au-dessus de 12 000 mètres, environ 39 000 pieds, dans l'instantané OpenSky actuel.",
+        "matters": "Sépare le trafic de croisière des mouvements locaux ou régionaux à plus basse altitude.",
+        "notMeaning": "Pas un score de danger et pas inhabituel en soi. Les jets commerciaux opèrent couramment à cette altitude.",
+        "example": "Haute altitude 2 signifie que seuls 2 avions suivis dans ce hotspot dépassaient le seuil de croisière à cet instantané."
+      },
+      {
+        "term": "Principaux pays",
+        "category": "Aérien",
+        "meaning": "Les valeurs origin_country les plus fréquentes d'OpenSky parmi les avions de ce hotspot.",
+        "matters": "Utile pour comprendre la composition approximative du trafic traversant un théâtre.",
+        "notMeaning": "Pas qui contrôle l'avion en ce moment et pas un indicateur direct de propriété militaire.",
+        "example": "Chine (61), Philippines (39), Taïwan (17) signifie que ceux-ci étaient les principaux pays d'origine enregistrés dans l'instantané."
+      },
+      {
+        "term": "FRP",
+        "category": "Thermique",
+        "meaning": "Puissance Radiative du Feu. C'est l'intensité d'un hotspot FIRMS spécifique, mesurée en mégawatts.",
+        "matters": "Un FRP plus élevé signifie généralement un événement de feu plus chaud, plus grand ou plus énergétique à ce point exact.",
+        "notMeaning": "Pas l'intensité de toute la région et pas une preuve automatique d'activité de conflit.",
+        "example": "Soudan / Corne de l'Afrique : FRP 92,3 MW décrit cet hotspot, tandis que Total 1 451 décrit le nombre total de détections régionales."
+      },
+      {
+        "term": "Détections totales",
+        "category": "Thermique",
+        "meaning": "Le nombre total de détections thermiques FIRMS dans le bucket régional entier pour le scan actuel.",
+        "matters": "Utile pour repérer des clusters de feu anormalement actifs, surtout comparé aux baselines historiques ou à l'activité nocturne.",
+        "notMeaning": "Pas un compte pour le point de carte unique sur lequel vous avez cliqué et pas nécessairement un compte de conflit.",
+        "example": "Total 1 451 signifie que le bucket Soudan / Corne de l'Afrique avait 1 451 détections lors de ce scan."
+      },
+      {
+        "term": "Détections nocturnes",
+        "category": "Thermique",
+        "meaning": "Détections thermiques marquées comme se produisant la nuit dans le bucket régional FIRMS plus large.",
+        "matters": "La chaleur nocturne peut être plus notable car elle est moins susceptible d'être un brûlage terrestre routinier diurne.",
+        "notMeaning": "Pas un indicateur de combat direct. Elle a toujours besoin de contexte de localisation, baseline et sources corroborantes.",
+        "example": "Nuit 140 signifie que 140 des 1 451 détections régionales étaient des détections nocturnes lors de ce scan."
+      },
+      {
+        "term": "Goulet d'étranglement",
+        "category": "Maritime",
+        "meaning": "Un corridor maritime stratégique ou un passage où les flux commerciaux et énergétiques peuvent être retardés, déviés ou interrompus.",
+        "matters": "Ces nœuds comptent car une perturbation ici peut affecter les coûts d'expédition, les temps de transit et les prix des matières premières à l'échelle mondiale.",
+        "notMeaning": "Pas une preuve qu'une perturbation se produit actuellement. C'est un emplacement de surveillance stratégique.",
+        "example": "Bab el-Mandeb ou le détroit d'Ormuz comptent car les flux d'expédition et d'énergie s'y concentrent."
+      },
+      {
+        "term": "Récepteur SDR",
+        "category": "Signaux",
+        "meaning": "Un récepteur radio définie par logiciel accessible publiquement dans ou près d'une région d'intérêt.",
+        "matters": "Une couverture dense de récepteurs peut vous donner plus de capacité à surveiller les communications ou l'activité signal dans un théâtre.",
+        "notMeaning": "Pas une preuve d'émissions hostiles ou une menace à elle seule. C'est une couche d'observation et de surveillance.",
+        "example": "Le nombre SDR de la mer de Chine méridionale signifie que des récepteurs KiwiSDR accessibles publiquement sont disponibles dans ou près de cette zone."
+      },
+      {
+        "term": "CPM",
+        "category": "Radiation",
+        "meaning": "Coups par minute d'une source de surveillance de radiation, utilisé ici pour l'état relatif de radiation d'un site.",
+        "matters": "Utile pour repérer des anomalies par rapport à la plage normale du site ou comparer des lectures consécutives.",
+        "notMeaning": "Pas un verdict de sécurité direct à lui seul. L'interprétation dépend de la baseline locale et de la tendance, pas du nombre brut seul.",
+        "example": "Une lecture de 33 CPM peut être normale si le niveau de fond habituel de cet emplacement est dans la même plage."
+      },
+      {
+        "term": "Spread HY",
+        "category": "Macro",
+        "meaning": "Écart de crédit high-yield, présenté ici comme proxy de stress à partir des données de crédit FRED.",
+        "matters": "Quand les écarts se creusent, les marchés pricent généralement plus de stress de crédit et des conditions financières plus restrictives.",
+        "notMeaning": "Pas un appel de récession à lui seul. C'est un signal de stress parmi d'autres.",
+        "example": "Un spread HY croissant avec VIX plus élevé et actions plus faibles est un pattern risk-off plus fort que HY seul."
+      },
+      {
+        "term": "VIX",
+        "category": "Macro",
+        "meaning": "L'indice de volatilité CBOE, couramment utilisé comme jauge de peur ou de volatilité implicite par le marché.",
+        "matters": "Un VIX plus élevé signifie souvent plus de volatilité équitaire attendue et un positionnement de marché plus défensif.",
+        "notMeaning": "Pas une prévision directe d'un krach et pas un indicateur géopolitique à lui seul.",
+        "example": "VIX au-dessus de 20 avec élargissement des spreads HY est un pattern de stress plus fort que VIX seul."
+      },
+      {
+        "term": "GSCPI",
+        "category": "Macro",
+        "meaning": "L'indice de pression sur la chaîne d'approvisionnement mondiale, un indicateur large de la tension sur les chaînes d'approvisionnement globales.",
+        "matters": "Il aide à traduire les perturbations géopolitiques ou météorologiques en pression probable sur l'expédition, les stocks et les prix.",
+        "notMeaning": "Pas un prix de marché en direct et pas un score de chaîne d'approvisionnement spécifique à une entreprise à lui seul.",
+        "example": "Un GSCPI plus élevé rend les chocs de route ou d'énergie plus susceptibles de se répandre en une pression de coûts plus large."
+      },
+      {
+        "term": "Alerte OMS",
+        "category": "Santé",
+        "meaning": "Un item Disease Outbreak News de l'OMS ou un bulletin lié à une épidémie apparu dans la couche santé.",
+        "matters": "Utile pour surveiller les épidémies qui pourraient affecter les voyages, les chaînes d'approvisionnement, le stress humanitaire ou les conditions opérationnelles régionales.",
+        "notMeaning": "Pas une déclaration de pandémie et pas automatiquement de haute sévérité.",
+        "example": "Une alerte OMS dans une région riche en ports compte plus si elle chevauche l'expédition, les contrôles frontaliers ou les signaux d'instabilité locale."
+      },
+      {
+        "term": "Delta de scan",
+        "category": "Plateforme",
+        "meaning": "Le résumé des changements entre le scan actuel et le précédent, y compris les signaux nouveaux, escaladés et désescaladés.",
+        "matters": "Utile pour repérer ce qui a récemment changé au lieu de relire le dashboard entier depuis le début.",
+        "notMeaning": "Pas un modèle de risque complet. C'est une couche de changement directionnelle au-dessus des signaux bruts.",
+        "example": "Un delta marqué risk-off avec plusieurs items nouveaux et escaladés signifie que le dernier scan a matériellement aggravé le mix de signaux."
+      }
+    ]
+  },
+  "loading": {
+    "title": "CRUCIX — Initialisation",
+    "statusCollecting": "COLLECTE DE DONNÉES...",
+    "statusProcessing": "TRAITEMENT DES SOURCES...",
+    "statusSynthesizing": "SYNTHÈSE DES SIGNAUX...",
+    "statusCorrelating": "CORRÉLATION DES FLUX...",
+    "statusAwaiting": "ATTENTE DE FINALISATION...",
+    "statusFinalizing": "FINALISATION...",
+    "statusReady": "TERMINAL PRÊT — CHARGEMENT DU DASHBOARD",
+    "eta": "PRÊT EST. DANS ~{remaining}s",
+    "awaitingSweep": "ATTENTE DE FINALISATION DU SCAN...",
+    "engine": "MOTEUR DE RENSEIGNEMENT CRUCIX v2.0.0",
+    "initiating": "DÉMARRAGE DU PREMIER SCAN...",
+    "connecting": "CONNEXION À 25 SOURCES OSINT",
+    "sources1": "GDELT · OPENSKY · FIRMS · MARITIME · SAFECAST",
+    "sources2": "FRED · BLS · EIA · TRÉSOR · GSCPI",
+    "sources3": "TELEGRAM · OMS · OFAC · ACLED · REDDIT · BLUESKY"
   }
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1,0 +1,516 @@
+{
+  "meta": {
+    "code": "zh",
+    "name": "Chinese",
+    "nativeName": "中文"
+  },
+  "dashboard": {
+    "title": "CRUCIX — 情报终端",
+    "bootTitle": "CRUCIX 情报引擎",
+    "bootSubtitle": "本地 Palantir · 31 个数据源",
+    "waitingForSweep": "等待首次扫描...",
+    "sourcesOk": "数据源正常",
+    "lastSweep": "上次扫描",
+    "nextSweep": "下次扫描",
+    "sweep": "扫描",
+    "sources": "数据源",
+    "delta": "变化量",
+    "highAlert": "高级警报",
+    "riskOff": "避险模式",
+    "riskOn": "风险偏好",
+    "mixed": "混合信号",
+    "terminalActive": "终端已激活",
+    "perf": "性能",
+    "perfLow": "低",
+    "perfHigh": "高",
+    "guideBtn": "信号含义说明"
+  },
+  "boot": {
+    "initializing": "正在初始化 CRUCIX 引擎 v2.1.0",
+    "connecting": "正在连接 {count} 个 OSINT 数据源...",
+    "sourceGroup1": "OPENSKY · FIRMS · KIWISDR · 海事",
+    "sourceGroup2": "FRED · BLS · EIA · 财政部 · GSCPI",
+    "sourceGroup3": "TELEGRAM · SAFECAST · EPA · 世卫组织 · OFAC",
+    "sourceGroup4": "GDELT · NOAA · 专利 · BLUESKY · REDDIT",
+    "sourceGroup5": "USGS · 欧洲央行 · CVE · COPERNICUS · CELESTRAK",
+    "sweepComplete": "扫描完成 — {ok}/{total} 个数据源",
+    "ok": "正常",
+    "acledLayer": "ACLED 冲突图层",
+    "events": "事件",
+    "degraded": "降级",
+    "flightCorridors": "飞行走廊",
+    "active": "活跃",
+    "dualProjection": "双投影",
+    "ready": "就绪",
+    "intelligenceSynthesis": "情报综合分析"
+  },
+  "panels": {
+    "sensorGrid": "传感器网格",
+    "tradeIdeas": "可操作策略",
+    "osintFeed": "OSINT 情报流",
+    "osintStream": "OSINT 数据流",
+    "nuclearWatch": "核监测",
+    "newsTicker": "实时新闻",
+    "sweepDelta": "扫描变化",
+    "macroMarkets": "宏观 + 市场",
+    "healthAlerts": "健康警报",
+    "riskGauges": "风险仪表",
+    "crossSourceSignals": "跨源信号",
+    "signalCore": "信号核心",
+    "seismicWatch": "地震监测",
+    "cyberWatch": "网络监测",
+    "spaceWatch": "太空监测",
+    "europeAlerts": "欧洲警报",
+    "ecbIndicators": "欧洲央行指标"
+  },
+  "layers": {
+    "airActivity": "空中活动",
+    "thermalSpikes": "热异常峰值",
+    "sdrCoverage": "SDR 覆盖范围",
+    "maritimeWatch": "海事监测",
+    "nuclearSites": "核设施",
+    "conflictEvents": "冲突事件",
+    "healthWatch": "健康监测",
+    "worldNews": "全球新闻",
+    "osintFeed": "OSINT 情报流",
+    "theaters": "战区",
+    "nightDet": "夜间探测",
+    "online": "在线",
+    "chokepoints": "咽喉要道",
+    "monitors": "监测站",
+    "fatalities": "伤亡",
+    "whoAlerts": "世卫组织警报",
+    "rssGeolocated": "RSS 地理定位",
+    "earthquakes": "地震",
+    "seismicEvents": "地震事件",
+    "cyberVulns": "网络漏洞",
+    "spaceActivity": "太空活动",
+    "europeEmergency": "欧洲紧急情况"
+  },
+  "map": {
+    "worldNews": "全球新闻",
+    "healthAlert": "健康警报",
+    "chokepoint": "咽喉要道",
+    "nuclearSite": "核设施",
+    "osintEvent": "OSINT 事件",
+    "thermalDetection": "热探测",
+    "aircraft": "飞行器",
+    "rssGeolocated": "RSS 地理定位",
+    "airTraffic": "空中交通",
+    "thermalFire": "热/火灾",
+    "conflict": "冲突",
+    "sdrReceiver": "SDR 接收器",
+    "scrollToZoom": "滚动缩放 · 拖动平移",
+    "globeMode": "地球模式",
+    "flatMode": "平面模式",
+    "earthquake": "地震",
+    "disaster": "灾害",
+    "weatherAlert": "天气警报",
+    "epaRadNet": "EPA 辐射监测网",
+    "spaceStation": "空间站",
+    "gdeltEvent": "GDELT 事件",
+    "initializing": "正在初始化 3D 地球仪",
+    "loadFailed": "3D 加载失败 · 平面模式",
+    "dragToRotate": "拖动旋转 · 滚动缩放"
+  },
+  "ideas": {
+    "confidence": "置信度",
+    "horizon": "时间跨度",
+    "risk": "风险",
+    "signals": "信号",
+    "rationale": "逻辑依据",
+    "aiEnhanced": "AI 增强",
+    "llmOff": "LLM 已关闭",
+    "pending": "等待中",
+    "llmNotConfigured": "LLM 未配置",
+    "llmHelp": "在 .env 中设置 LLM_PROVIDER 和相关凭证以启用 AI 驱动的策略建议",
+    "disclosure": "仅供参考。本文不构成财务建议、买卖证券的推荐或任何形式的要约。所有基于信号的观察均来源于公开可获取的 OSINT 数据，不应作为投资决策的依据。在进行任何投资前，请咨询持牌财务顾问。过往业绩不代表未来表现。"
+  },
+  "regions": {
+    "world": "全球",
+    "americas": "美洲",
+    "europe": "欧洲",
+    "middleEast": "中东",
+    "asiaPacific": "亚太",
+    "africa": "非洲"
+  },
+  "badges": {
+    "radiation": "辐射",
+    "live": "实时",
+    "delayed": "延迟",
+    "items": "条目",
+    "urgent": "紧急",
+    "worldview": "全球视角",
+    "hotMetrics": "热门指标",
+    "stress": "压力",
+    "sweeping": "扫描中...",
+    "europe": "欧洲",
+    "orbital": "轨道",
+    "views": "次浏览"
+  },
+  "delta": {
+    "baseline": "基准线",
+    "escalation": "升级",
+    "deescalation": "降级",
+    "stable": "稳定",
+    "newSignals": "新信号",
+    "resolved": "已解决",
+    "noChanges": "自上次扫描以来无变化",
+    "changes": "变化",
+    "critical": "严重",
+    "new": "新增"
+  },
+  "metrics": {
+    "wtiCrude": "WTI 原油",
+    "brent": "布伦特原油",
+    "natGas": "天然气",
+    "vix": "VIX 波动率",
+    "fedFunds": "联邦基金利率",
+    "gscpi": "GSCPI",
+    "cpiMom": "CPI 环比",
+    "unemployment": "失业率",
+    "hySpread": "高收益利差",
+    "usdIndex": "美元指数",
+    "joblessClaims": "初请失业金",
+    "mortgage30y": "30 年房贷利率",
+    "m2Supply": "M2 供应量",
+    "natDebt": "国债",
+    "wti5day": "WTI 五日走势",
+    "indexes": "指数",
+    "crypto": "加密货币",
+    "energyMacro": "能源 + 宏观",
+    "vsPrior": "较前值",
+    "ecbRate": "欧洲央行利率",
+    "eurusd": "欧元/美元",
+    "euM3": "欧盟 M3",
+    "euHicp": "欧盟 HICP",
+    "earthquakes7d": "地震（7天）",
+    "criticalCves": "严重 CVE",
+    "spaceObjects": "太空物体",
+    "starlink": "星链",
+    "europeAlerts": "欧盟警报"
+  },
+  "signalMetrics": {
+    "incidentTempo": "事件节奏",
+    "airTheaters": "空中战区",
+    "thermalSpikes": "热异常峰值",
+    "sdrNodes": "SDR 节点",
+    "chokepoints": "咽喉要道",
+    "whoAlerts": "世卫组织警报"
+  },
+  "nuclear": {
+    "allSitesNormal": "所有设施正常",
+    "anomalyDetected": "检测到异常",
+    "noData": "无数据"
+  },
+  "seismic": {
+    "noRecentQuakes": "无重大地震",
+    "majorQuake": "检测到重大地震",
+    "tsunamiRisk": "海啸风险",
+    "mag": "震级"
+  },
+  "cyber": {
+    "noAlerts": "无严重 CVE",
+    "criticalAlert": "严重漏洞",
+    "cvss": "CVSS",
+    "critical": "严重"
+  },
+  "space": {
+    "noActivity": "活动正常",
+    "launchDetected": "检测到发射活动",
+    "objectsTracked": "追踪物体数",
+    "newLast30d": "新增（30天）",
+    "satellites": "卫星",
+    "recentLaunches": "近期发射",
+    "totalTracked": "总计追踪",
+    "byCountry": "按国家",
+    "constellations": "星座",
+    "launches": "发射",
+    "militarySats": "军事卫星",
+    "milSats": "颗军事卫星",
+    "noData": "无太空数据"
+  },
+  "europe": {
+    "noAlerts": "无活跃警报",
+    "activeAlerts": "活跃警报",
+    "fires": "火灾",
+    "floods": "洪水",
+    "types": "类型"
+  },
+  "time": {
+    "justNow": "刚刚",
+    "hoursAgo": "{hours}小时前",
+    "daysAgo": "{days}天前"
+  },
+  "bot": {
+    "commands": {
+      "status": "获取系统健康状态、上次扫描时间和数据源状态",
+      "sweep": "触发手动扫描周期",
+      "brief": "获取最新情报的精简文本摘要",
+      "portfolio": "显示当前持仓和盈亏（如已连接 Alpaca）",
+      "alerts": "显示近期警报历史",
+      "mute": "静音警报 1 小时（或 /mute 2h、/mute 4h）",
+      "unmute": "恢复警报",
+      "help": "显示可用命令"
+    },
+    "messages": {
+      "alertsMuted": "🔇 警报已静音 {hours} 小时 — 至 {time} UTC",
+      "useUnmute": "使用 /unmute 恢复。",
+      "alertsResumed": "🔔 警报已恢复。您将收到下一次信号评估。",
+      "sweepTriggered": "🚀 已触发手动扫描。如检测到重大事件，您将收到警报。",
+      "sweepInProgress": "🔄 扫描正在进行中，请稍候。",
+      "noDataYet": "⏳ 尚无数据 — 等待首次扫描完成。",
+      "noRecentAlerts": "近期无警报。",
+      "recentAlerts": "📋 近期警报（最近 {count} 条）",
+      "commandsTip": "提示：命令不区分大小写",
+      "commandFailed": "❌ 命令执行失败：{error}",
+      "portfolioNotAvailable": "📊 投资组合集成需要连接 Alpaca MCP。\n请使用 Crucix 仪表盘或 Claude 代理进行投资组合查询。"
+    },
+    "status": {
+      "title": "🖥️ CRUCIX 状态",
+      "uptime": "运行时间",
+      "lastSweep": "上次扫描",
+      "nextSweep": "下次扫描",
+      "sweepInProgress": "扫描进行中",
+      "yes": "🔄 是",
+      "no": "⏸️ 否",
+      "sources": "数据源",
+      "failed": "失败",
+      "llm": "LLM",
+      "enabled": "✅ 已启用",
+      "disabled": "❌ 已禁用",
+      "sseClients": "SSE 客户端",
+      "dashboard": "仪表盘",
+      "pending": "等待中",
+      "never": "从未"
+    },
+    "brief": {
+      "title": "📋 CRUCIX 简报",
+      "direction": "方向",
+      "changes": "变化",
+      "criticalChanges": "严重变化",
+      "osint": "📡 OSINT",
+      "urgentSignals": "紧急信号",
+      "totalPosts": "总帖子数",
+      "topIdeas": "💡 热门策略"
+    },
+    "alertTiers": {
+      "flash": "紧急",
+      "priority": "优先",
+      "routine": "常规"
+    }
+  },
+  "alerts": {
+    "tiers": {
+      "flash": {
+        "label": "紧急",
+        "description": "需立即行动 — 影响市场、时间紧迫"
+      },
+      "priority": {
+        "label": "优先",
+        "description": "重要信号集群 — 需在数小时内行动"
+      },
+      "routine": {
+        "label": "常规",
+        "description": "值得注意的变化 — 仅供参考，无紧迫性"
+      }
+    },
+    "confidence": {
+      "high": "高",
+      "medium": "中",
+      "low": "低"
+    },
+    "fields": {
+      "direction": "方向",
+      "confidence": "置信度",
+      "crossCorrelation": "跨域关联",
+      "action": "行动",
+      "signals": "信号",
+      "monitor": "监控"
+    },
+    "messages": {
+      "alertsMuted": "警报已静音",
+      "mutedUntil": "警报已静音 {hours} 小时 — 至 {time} UTC。",
+      "useUnmuteToResume": "使用 /unmute 恢复。",
+      "alertsResumed": "警报已恢复",
+      "willReceiveNext": "您将收到下一次信号评估。"
+    },
+    "ruleBasedHeadlines": {
+      "nuclearAnomaly": "检测到核异常",
+      "crossDomainSignals": "{count} 个严重跨域信号",
+      "escalatingSignals": "{count} 个升级信号",
+      "osintSurge": "OSINT 激增：{count} 条新紧急帖子",
+      "signalChangeDetected": "检测到信号变化"
+    }
+  },
+  "discord": {
+    "commands": {
+      "status": "系统健康状态、上次扫描时间和数据源状态",
+      "sweep": "触发手动扫描周期",
+      "brief": "精简情报摘要",
+      "portfolio": "投资组合状态（如已连接 Alpaca）",
+      "alerts": "近期警报历史",
+      "mute": "静音警报（默认 1 小时）",
+      "unmute": "恢复警报",
+      "muteHoursOption": "静音时长（默认：1）"
+    }
+  },
+  "llm": {
+    "systemPrompt": "你是一家宏观情报公司的量化分析师。你接收来自 25 个来源的结构化 OSINT + 经济数据，并产出 5-8 条可执行的交易策略。\n\n规则：\n- 每条策略必须引用输入中的具体数据点\n- 包含入场逻辑、风险因素和时间跨度\n- 融合地缘政治、经济和市场信号 — 跨领域交叉关联\n- 具体明确：指明工具（代码、期货、ETF），而非模糊的行业\n- 如变化量（delta）显示重大变化，优先从这些开始\n- 除非条件已实质变化，否则不要重复\"先前策略\"列表中的想法\n- 评估置信度：HIGH（多个确认信号）、MEDIUM（论点有支持）、LOW（推测性）\n\n仅输出有效的 JSON 数组。每个对象：\n{\n  \"title\": \"简短标题（最多 10 个词）\",\n  \"type\": \"LONG|SHORT|HEDGE|WATCH|AVOID\",\n  \"ticker\": \"主要工具\",\n  \"confidence\": \"HIGH|MEDIUM|LOW\",\n  \"rationale\": \"2-3 句解释，引用具体数据\",\n  \"risk\": \"主要风险因素\",\n  \"horizon\": \"Intraday|Days|Weeks|Months\",\n  \"signals\": [\"signal1\", \"signal2\"]\n}"
+  },
+  "api": {
+    "errors": {
+      "noDataYet": "尚无数据 — 首次扫描进行中"
+    }
+  },
+  "glossary": {
+    "kicker": "信号指南",
+    "title": "这些信号到底意味着什么",
+    "subtitle": "通俗解读、重要性说明以及你不应从中推断的内容。",
+    "foot": "请将这些视为解读指南，而非结论。更可靠的判断应来自多层面交叉验证，而非单一信号的孤立观察。",
+    "labelMeaning": "含义",
+    "labelMatters": "为何重要",
+    "labelNotProof": "不能证明什么",
+    "labelExample": "示例",
+    "categoryAir": "空中",
+    "categoryThermal": "热成像",
+    "categoryMaritime": "海事",
+    "categorySignals": "信号",
+    "categoryRadiation": "辐射",
+    "categoryMacro": "宏观",
+    "categoryHealth": "健康",
+    "categoryPlatform": "平台",
+    "items": [
+      {
+        "term": "无呼号",
+        "category": "空中",
+        "meaning": "OpenSky 接收到一条没有可用呼号或航班标识的飞机航迹记录。",
+        "matters": "可作为透明度信号。集中出现的无呼号航迹可能表明应答机元数据不完整或流量透明度较低。",
+        "notMeaning": "不能单独证明军事、隐蔽或敌对活动。",
+        "example": "南海：无呼号 6/152 表示该战区有 6 条航迹在数据流中没有可用呼号。"
+      },
+      {
+        "term": "高空飞行",
+        "category": "空中",
+        "meaning": "当前 OpenSky 快照中高度超过 12,000 米（约 39,000 英尺）的飞机。",
+        "matters": "将巡航高度流量与低空本地或区域性移动区分开来。",
+        "notMeaning": "不是危险评分，也并非异常。商业客机通常在此高度运行。",
+        "example": "高空飞行 2 表示该热点区域仅有 2 架被追踪飞机在该快照时刻高于巡航阈值。"
+      },
+      {
+        "term": "主要国家",
+        "category": "空中",
+        "meaning": "该热点区域飞机中最常见的 OpenSky origin_country（注册国籍）值。",
+        "matters": "有助于了解流经该战区的大致流量构成。",
+        "notMeaning": "不代表当前谁在控制飞机，也不是军事所有权的直接指标。",
+        "example": "中国（61）、菲律宾（39）、台湾（17）表示这些是该快照中注册国籍最多的国家。"
+      },
+      {
+        "term": "FRP 火辐射功率",
+        "category": "热成像",
+        "meaning": "火辐射功率（Fire Radiative Power）。这是 FIRMS 某一特定热点的强度，以兆瓦为单位。",
+        "matters": "更高的 FRP 通常意味着该点位更热、更大或能量更足的火情。",
+        "notMeaning": "不是整个区域的强度，也不能自动证明冲突活动。",
+        "example": "苏丹/非洲之角：FRP 92.3 MW 描述的是那一个热点，而总计 1,451 描述的是整个区域检测总数。"
+      },
+      {
+        "term": "总检测数",
+        "category": "热成像",
+        "meaning": "当前扫描中 FIRMS 热成像在整个区域桶内的总检测数。",
+        "matters": "有助于发现异常活跃的火群，特别是与历史基线或夜间活动对比时。",
+        "notMeaning": "不是你点击的单个地图点的计数，也不一定是冲突计数。",
+        "example": "总计 1,451 表示苏丹/非洲之角整个区域桶在该次扫描中有 1,451 次检测。"
+      },
+      {
+        "term": "夜间检测",
+        "category": "热成像",
+        "meaning": "在更广泛的 FIRMS 区域桶内标记为夜间发生的热成像检测。",
+        "matters": "夜间热源更值得关注，因为不太可能是常规的日间焚烧。",
+        "notMeaning": "不是直接的战斗指标。仍需要结合位置、基线和佐证来源进行判断。",
+        "example": "夜间 140 表示 1,451 次区域检测中有 140 次是夜间检测。"
+      },
+      {
+        "term": "咽喉要道",
+        "category": "海事",
+        "meaning": "战略性海上走廊或通道，贸易和能源流动可能在此被延迟、改道或中断。",
+        "matters": "这些节点很重要，因为此处的中断可能影响全球航运成本、运输时间和商品价格。",
+        "notMeaning": "不能证明 disruption 正在发生。这是一个战略性监视位置。",
+        "example": "曼德海峡或霍尔木兹海峡很重要，因为航运和能源流动集中于此。"
+      },
+      {
+        "term": "SDR 接收器",
+        "category": "信号",
+        "meaning": "感兴趣区域内部或附近的公开可访问软件定义无线电接收器。",
+        "matters": "密集的接收器覆盖能让你更有能力监测战区内的通信或信号活动。",
+        "notMeaning": "不是敌对发射的证据，本身也不构成威胁。它是一个观察和监测层。",
+        "example": "南海 SDR 数量表示该区域或其附近有可公开访问的 KiwiSDR 接收器。"
+      },
+      {
+        "term": "CPM 计数/分钟",
+        "category": "辐射",
+        "meaning": "辐射监测源的每分钟计数，此处用于某站点的相对辐射状态。",
+        "matters": "有助于发现与站点正常范围的异常，或比较连续读数。",
+        "notMeaning": "不能单独作为安全判决。解读取决于当地基线和趋势，而非原始数字本身。",
+        "example": "如果某位置的常规背景水平也在同一范围内，则读数为 33 CPM 可能是正常的。"
+      },
+      {
+        "term": "高收益利差",
+        "category": "宏观",
+        "meaning": "高收益信贷利差，此处作为 FRED 信用数据中的压力代理指标。",
+        "matters": "当利差扩大时，市场通常正在定价更多信用压力和更紧张的金融条件。",
+        "notMeaning": "不能单独作为衰退预测。它只是众多压力信号之一。",
+        "example": "高收益利差上升同时伴随 VIX 升高和股票走弱，是比单一 HY 利差更强的避险模式。"
+      },
+      {
+        "term": "VIX 波动率指数",
+        "category": "宏观",
+        "meaning": "芝加哥期权交易所波动率指数，通常用作市场隐含的恐惧或波动率指标。",
+        "matters": "更高的 VIX 通常意味着预期股票波动率更高，市场配置更偏防御。",
+        "notMeaning": "不是崩盘的直接预测，本身也不是地缘政治指标。",
+        "example": "VIX 高于 20 且高收益利差扩大，是比单一 VIX 更强的压力模式。"
+      },
+      {
+        "term": "GSCPI 供应链压力指数",
+        "category": "宏观",
+        "meaning": "全球供应链压力指数，衡量全球供应链紧张程度的广泛指标。",
+        "matters": "有助于将地缘政治或天气中断转化为对航运、库存和价格的潜在压力。",
+        "notMeaning": "不是实时市场价格，本身也不是公司特定的供应链评分。",
+        "example": "更高的 GSCPI 使航线或能源冲击更有可能蔓延到更广泛的价格压力。"
+      },
+      {
+        "term": "世卫组织警报",
+        "category": "健康",
+        "meaning": "世卫组织疾病暴发新闻项目或与健康层相关的疫情公告。",
+        "matters": "有助于监测可能影响旅行、供应链、人道主义压力或区域运营条件的疫情。",
+        "notMeaning": "不是大流行声明，也不自动代表高严重度。",
+        "example": "如果世卫组织警报与航运、边境管制或当地不稳定信号重叠，则在港口密集区域更重要。"
+      },
+      {
+        "term": "扫描变化量",
+        "category": "平台",
+        "meaning": "当前扫描与上一次扫描之间的变化摘要，包括新增、升级和降级的信号。",
+        "matters": "有助于发现最近的变化，而不必从头重新阅读整个仪表盘。",
+        "notMeaning": "不是完整的风险模型。它是原始信号之上的方向性变化层。",
+        "example": "标记为 risk-off 且有多个新增和升级项的变化量意味着最新扫描在实质上恶化了信号组合。"
+      }
+    ]
+  },
+  "loading": {
+    "title": "CRUCIX — 初始化中",
+    "statusCollecting": "正在收集数据...",
+    "statusProcessing": "正在处理数据源...",
+    "statusSynthesizing": "正在合成信号...",
+    "statusCorrelating": "正在关联数据流...",
+    "statusAwaiting": "等待完成...",
+    "statusFinalizing": "正在完成...",
+    "statusReady": "终端就绪 — 正在加载仪表盘",
+    "eta": "预计 ~{remaining} 秒后就绪",
+    "awaitingSweep": "等待扫描完成...",
+    "engine": "CRUCIX 情报引擎 v2.0.0",
+    "initiating": "正在启动首次扫描...",
+    "connecting": "正在连接 25 个 OSINT 数据源",
+    "sources1": "GDELT · OPENSKY · FIRMS · 海事 · SAFECAST",
+    "sources2": "FRED · BLS · EIA · 财政部 · GSCPI",
+    "sources3": "TELEGRAM · 世卫组织 · OFAC · ACLED · REDDIT · BLUESKY"
+  }
+}

--- a/server.mjs
+++ b/server.mjs
@@ -14,6 +14,7 @@ import { synthesize, generateIdeas } from './dashboard/inject.mjs';
 import { MemoryManager } from './lib/delta/index.mjs';
 import { createLLMProvider } from './lib/llm/index.mjs';
 import { generateLLMIdeas } from './lib/llm/ideas.mjs';
+import { translateNewsFeed, translateTelegramPosts } from './lib/llm/translate.mjs';
 import { TelegramAlerter } from './lib/alerts/telegram.mjs';
 import { DiscordAlerter } from './lib/alerts/discord.mjs';
 
@@ -239,7 +240,13 @@ app.use(express.static(join(ROOT, 'dashboard/public')));
 // Serve loading page until first sweep completes, then the dashboard with injected locale
 app.get('/', (req, res) => {
   if (!currentData) {
-    res.sendFile(join(ROOT, 'dashboard/public/loading.html'));
+    const htmlPath = join(ROOT, 'dashboard/public/loading.html');
+    let html = readFileSync(htmlPath, 'utf-8');
+    const locale = getLocale();
+    const localeScript = `<script>window.__CRUCIX_LOCALE__ = ${JSON.stringify(locale).replace(/<\/script>/gi, '<\\/script>')};</script>`;
+    html = html.replace('</head>', `${localeScript}\n</head>`);
+    html = html.replace('<html lang="en">', `<html lang="${currentLanguage}">`);
+    res.type('html').send(html);
   } else {
     const htmlPath = join(ROOT, 'dashboard/public/jarvis.html');
     let html = readFileSync(htmlPath, 'utf-8');
@@ -248,6 +255,13 @@ app.get('/', (req, res) => {
     const locale = getLocale();
     const localeScript = `<script>window.__CRUCIX_LOCALE__ = ${JSON.stringify(locale).replace(/<\/script>/gi, '<\\/script>')};</script>`;
     html = html.replace('</head>', `${localeScript}\n</head>`);
+    html = html.replace('<html lang="en">', `<html lang="${currentLanguage}">`);
+    
+    // Replace hardcoded demo data with current sweep data
+    if (currentData) {
+      const json = JSON.stringify(currentData);
+      html = html.replace(/^(let|const) D = .*;\s*$/m, () => 'let D = ' + json + ';');
+    }
     
     res.type('html').send(html);
   }
@@ -356,6 +370,46 @@ async function runSweepCycle() {
         console.error('[Crucix] LLM ideas failed (non-fatal):', llmErr.message);
         synthesized.ideas = [];
         synthesized.ideasSource = 'llm-failed';
+      }
+
+      // 5b. Translate news feed + OSINT posts to Chinese if language is zh
+      if (currentLanguage === 'zh') {
+        if (synthesized.newsFeed?.length) {
+          try {
+            console.log('[Crucix] Translating news feed to Chinese...');
+            const translated = await translateNewsFeed(llmProvider, synthesized.newsFeed, 'zh');
+            if (translated && translated !== synthesized.newsFeed) {
+              synthesized.newsFeed = translated;
+              console.log(`[Crucix] Translated ${translated.filter(n => n._translated).length} news items`);
+            }
+          } catch (transErr) {
+            console.error('[Crucix] News translation failed (non-fatal):', transErr.message);
+          }
+        }
+        if (synthesized.tg?.urgent?.length) {
+          try {
+            console.log('[Crucix] Translating OSINT urgent posts to Chinese...');
+            const translated = await translateTelegramPosts(llmProvider, synthesized.tg.urgent, 'zh');
+            if (translated && translated !== synthesized.tg.urgent) {
+              synthesized.tg.urgent = translated;
+              console.log(`[Crucix] Translated ${translated.filter(n => n._translated).length} urgent OSINT posts`);
+            }
+          } catch (transErr) {
+            console.error('[Crucix] OSINT translation failed (non-fatal):', transErr.message);
+          }
+        }
+        if (synthesized.tg?.topPosts?.length) {
+          try {
+            console.log('[Crucix] Translating OSINT top posts to Chinese...');
+            const translated = await translateTelegramPosts(llmProvider, synthesized.tg.topPosts, 'zh');
+            if (translated && translated !== synthesized.tg.topPosts) {
+              synthesized.tg.topPosts = translated;
+              console.log(`[Crucix] Translated ${translated.filter(n => n._translated).length} top OSINT posts`);
+            }
+          } catch (transErr) {
+            console.error('[Crucix] OSINT translation failed (non-fatal):', transErr.message);
+          }
+        }
       }
     } else {
       synthesized.ideas = [];

--- a/test/llm-deepseek-integration.test.mjs
+++ b/test/llm-deepseek-integration.test.mjs
@@ -1,0 +1,26 @@
+// DeepSeek Provider Integration Test
+// Run: DEEPSEEK_API_KEY=sk-... node --test test/llm-deepseek-integration.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DeepSeekProvider } from '../lib/llm/deepseek.mjs';
+
+const API_KEY = process.env.DEEPSEEK_API_KEY || process.env.LLM_API_KEY;
+
+test('DeepSeekProvider Integration Test', { skip: !API_KEY }, async (t) => {
+  const provider = new DeepSeekProvider({
+    apiKey: API_KEY,
+    model: process.env.LLM_MODEL || 'deepseek-chat',
+  });
+
+  await t.test('should complete a prompt with deepseek-chat', async () => {
+    const result = await provider.complete(
+      'You are a helpful assistant. Reply with a single word.',
+      'What is the capital of France?'
+    );
+    assert.ok(result.text.length > 0, 'Expected non-empty response');
+    assert.ok(result.usage.inputTokens > 0, 'Expected input tokens');
+    assert.ok(result.usage.outputTokens > 0, 'Expected output tokens');
+    console.log('DeepSeek response:', result.text.substring(0, 100));
+  });
+});

--- a/test/llm-deepseek.test.mjs
+++ b/test/llm-deepseek.test.mjs
@@ -1,0 +1,135 @@
+// DeepSeek provider — unit tests
+// Uses Node.js built-in test runner (node:test) — no extra dependencies
+
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { DeepSeekProvider } from '../lib/llm/deepseek.mjs';
+import { createLLMProvider } from '../lib/llm/index.mjs';
+
+// ─── Unit Tests ───
+
+describe('DeepSeekProvider', () => {
+  it('should set defaults correctly', () => {
+    const provider = new DeepSeekProvider({ apiKey: 'sk-test' });
+    assert.equal(provider.name, 'deepseek');
+    assert.equal(provider.model, 'deepseek-chat');
+    assert.equal(provider.isConfigured, true);
+  });
+
+  it('should accept custom model', () => {
+    const provider = new DeepSeekProvider({ apiKey: 'sk-test', model: 'deepseek-reasoner' });
+    assert.equal(provider.model, 'deepseek-reasoner');
+  });
+
+  it('should report not configured without API key', () => {
+    const provider = new DeepSeekProvider({});
+    assert.equal(provider.isConfigured, false);
+  });
+
+  it('should throw on API error', async () => {
+    const provider = new DeepSeekProvider({ apiKey: 'sk-test' });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(() =>
+      Promise.resolve({ ok: false, status: 401, text: () => Promise.resolve('Unauthorized') })
+    );
+    try {
+      await assert.rejects(
+        () => provider.complete('system', 'user'),
+        (err) => {
+          assert.match(err.message, /DeepSeek API 401/);
+          return true;
+        }
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should parse successful response', async () => {
+    const provider = new DeepSeekProvider({ apiKey: 'sk-test' });
+    const mockResponse = {
+      choices: [{ message: { content: 'Hello world' } }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+      model: 'deepseek-chat'
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+    );
+    try {
+      const result = await provider.complete('system', 'user');
+      assert.equal(result.text, 'Hello world');
+      assert.equal(result.usage.inputTokens, 10);
+      assert.equal(result.usage.outputTokens, 5);
+      assert.equal(result.model, 'deepseek-chat');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should send correct request format', async () => {
+    const provider = new DeepSeekProvider({ apiKey: 'sk-test-key', model: 'deepseek-chat' });
+    let capturedUrl, capturedOpts;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn((url, opts) => {
+      capturedUrl = url;
+      capturedOpts = opts;
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'ok' } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+          model: 'deepseek-chat',
+        }),
+      });
+    });
+    try {
+      await provider.complete('system prompt', 'user message', { maxTokens: 2048 });
+      assert.equal(capturedUrl, 'https://api.deepseek.com/v1/chat/completions');
+      assert.equal(capturedOpts.method, 'POST');
+      const headers = capturedOpts.headers;
+      assert.equal(headers['Content-Type'], 'application/json');
+      assert.equal(headers.Authorization, 'Bearer sk-test-key');
+      const body = JSON.parse(capturedOpts.body);
+      assert.equal(body.model, 'deepseek-chat');
+      assert.equal(body.max_tokens, 2048);
+      assert.equal(body.temperature, 0);
+      assert.equal(body.stream, false);
+      assert.equal(body.messages[0].role, 'system');
+      assert.equal(body.messages[0].content, 'system prompt');
+      assert.equal(body.messages[1].role, 'user');
+      assert.equal(body.messages[1].content, 'user message');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('should handle empty response gracefully', async () => {
+    const provider = new DeepSeekProvider({ apiKey: 'sk-test' });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ choices: [], usage: {} }),
+      })
+    );
+    try {
+      const result = await provider.complete('sys', 'user');
+      assert.equal(result.text, '');
+      assert.equal(result.usage.inputTokens, 0);
+      assert.equal(result.usage.outputTokens, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+// ─── Factory Tests ───
+
+describe('createLLMProvider', () => {
+  it('should create DeepSeek provider', () => {
+    const provider = createLLMProvider({ provider: 'deepseek', apiKey: 'sk-test' });
+    assert.ok(provider instanceof DeepSeekProvider);
+    assert.equal(provider.isConfigured, true);
+  });
+});


### PR DESCRIPTION
- Add complete zh.json locale (359 keys) with dashboard, boot, panels, map, layers, signal guide glossary, and LLM system prompts
- Add DeepSeek LLM provider (lib/llm/deepseek.mjs) with OpenAI-compatible API
- Add LLM batch translation pipeline (lib/llm/translate.mjs) for news headlines and OSINT Telegram posts, auto-translates to Chinese when CRUCIX_LANG=zh
- Update i18n system to support zh with SUPPORTED_LOCALES=['en','fr','zh']
- Inject locale and live data into jarvis.html/loading.html at serve time
- Internationalize dashboard: all hardcoded English wrapped with t(), including Signal Guide glossary items
- Update Docker setup: fix Dockerfile --omit=dev, compose network_mode: host
- Add unit tests for DeepSeek provider
- Update server.mjs to run translation after LLM ideas generation

## Summary

Describe what changed.

## Why

Explain the problem being solved.

## Scope

- [ ] Focused bug fix
- [ ] Small UX improvement
- [ ] New source
- [ ] Dashboard change
- [ ] Docs/config change

## Validation

List the commands, checks, or manual validation you performed.

## Screenshots

If the dashboard or any visible output changed, add screenshots.

## Config and Docs

- [ ] No new environment variables
- [ ] `.env.example` updated if needed
- [ ] `README.md` updated if behavior changed

## Source Additions

If this PR adds a new source, explain:

- why the source improves signal quality
- whether it requires an API key
- how it degrades when the key is missing
- what changed in `apis/briefing.mjs` and `dashboard/inject.mjs`

## Checklist

- [ ] This PR stays within one bugfix or one feature family
- [ ] I kept unrelated changes out of the diff
- [ ] I considered security for any mixed-source content rendering
- [ ] I tested the changed path locally
